### PR TITLE
Switch to iip for regression and edmd

### DIFF
--- a/src/koopman/extended_dmd.jl
+++ b/src/koopman/extended_dmd.jl
@@ -32,8 +32,10 @@ function EDMD(X::AbstractArray, Y::AbstractArray, Ψ::AbstractBasis; p::Abstract
     N,M = size(X)
 
     # Compute the transformed data
-    Ψ₀ = Ψ(X, p, t)
-    Ψ₁ = Ψ(Y, p, t)
+    Ψ₀ = zeros(eltype(X), length(Ψ), size(X, 2))
+    Ψ₁ = zeros(eltype(X), length(Ψ), size(Y, 2))
+    Ψ(Ψ₀, X, p, t)
+    Ψ(Ψ₁, Y, p, t)
 
     A = alg(Ψ₀, Ψ₁)
 
@@ -56,7 +58,10 @@ function gEDMD(X::AbstractArray, DX::AbstractArray, Ψ::AbstractBasis; p::Abstra
     N,M = size(X)
 
     # Compute the transformed data
-    Ψ₀ = Ψ(X, p, t)
+    
+    # Compute the transformed data
+    Ψ₀ = zeros(eltype(X), length(Ψ), size(X, 2))
+    Ψ(Ψ₀, X, p, t)
 
     # The jacobian to get d/dt(Ψ) = d/dx(Ψ) dx/dt
     ∇ = jacobian(Ψ)

--- a/src/sindy/isindy.jl
+++ b/src/sindy/isindy.jl
@@ -32,7 +32,8 @@ function ISINDy(X::AbstractArray, Ẋ::AbstractArray, Ψ::Basis, opt::T = ADM();
     @assert size(X)[end] == size(Ẋ)[end]
 
     # Compute the library and the corresponding nullspace
-    θ = Ψ(X, p, t)
+    θ = zeros(eltype(X), length(Ψ), size(X, 2))
+    Ψ(θ, X, p, t)
 
     # Init for sweep over the differential variables
     Ξ = zeros(eltype(θ), length(Ψ)*2, size(Ẋ, 1))
@@ -47,7 +48,9 @@ function ISINDy(X::AbstractArray, Ẋ::AbstractArray, Ψ::Basis, opt::T; f::Func
     @assert size(X)[end] == size(Ẋ)[end]
 
     # Compute the library and the corresponding nullspace
-    θ = Ψ(X, p, t)
+    θ = zeros(eltype(X), length(Ψ), size(X, 2))
+    Ψ(θ, X, p, t)
+
     dθ = zeros(eltype(θ), size(θ, 1)*2, size(θ, 2))
     dθ[size(θ, 1)+1:end, :] .= θ
 
@@ -77,9 +80,11 @@ end
 
 function ISINDy(X::AbstractArray, Ẋ::AbstractArray, Ψ::Basis, thresholds::AbstractVector, opt::T = STRRidge(); f::Function = (xi, theta)->[norm(xi, 0); norm(theta'*xi, 2)], g::Function = x->norm(x), maxiter::Int64 = 10, rtol::Float64 = 0.99, p::AbstractArray = [], t::AbstractVector = [], convergence_error = eps(), normalize::Bool = true, denoise::Bool = false) where T <: DataDrivenDiffEq.Optimize.AbstractOptimizer
     @assert size(X)[end] == size(Ẋ)[end]
-
+    
     # Compute the library and the corresponding nullspace
-    θ = Ψ(X, p, t)
+    θ = zeros(eltype(X), length(Ψ), size(X, 2))
+    Ψ(θ, X, p, t)
+    
     dθ = zeros(eltype(θ), size(θ, 1)*2, size(θ, 2))
     dθ[size(θ, 1)+1:end, :] .= θ
 

--- a/src/sindy/sindy.jl
+++ b/src/sindy/sindy.jl
@@ -61,7 +61,9 @@ function sparse_regression(X::AbstractArray, Ẋ::AbstractArray, Ψ::Basis, p::A
 
     Ξ = zeros(eltype(X), length(Ψ), ny)
     scales = ones(eltype(X), length(Ψ))
-    θ = Ψ(X, p, t)
+    θ = zeros(eltype(X), length(Ψ), nm)
+    Ψ(θ, X, p, t)
+
 
     denoise ? optimal_shrinkage!(θ') : nothing
     normalize ? normalize_theta!(scales, θ) : nothing
@@ -81,8 +83,9 @@ function sparse_regression!(Ξ::AbstractArray, X::AbstractArray, Ẋ::AbstractAr
     @assert size(Ξ) == (length(Ψ), ny)
 
     scales = ones(eltype(X), length(Ψ))
-    θ = Ψ(X, p, t)
-
+    θ = zeros(eltype(X), length(Ψ), nm)
+    Ψ(θ, X, p, t)
+    
     denoise ? optimal_shrinkage!(θ') : nothing
     normalize ? normalize_theta!(scales, θ) : nothing
 


### PR DESCRIPTION
Changes  to make sparse_regression faster.

```julia
using BenchmarkTools
# From the lorenz example with ideal data
opt = STRRidge(0.001)

# Before
@btime Ξ, iters = DataDrivenDiffEq.sparse_regression(X, DX, basis, [], [], 100, opt, false, false, eps())
# 5.587 s (13061347 allocations: 7.51 GiB)

# After
@btime Ξ, iters = DataDrivenDiffEq.sparse_regression(X, DX, basis, [], [], 100, opt, false, false, eps())
# 698.537 ms (100697 allocations: 72.65 MiB)
```