### PR TITLE
Fix \min to \argmin

### DIFF
--- a/docs/src/sparse_identification/sindy.md
+++ b/docs/src/sparse_identification/sindy.md
@@ -3,7 +3,7 @@
 [Sparse Identification of Nonlinear Dynamics](https://www.pnas.org/content/113/15/3932) - or SINDy - identifies the equations of motion of a system as the result of a sparse regression over a chosen basis. In particular, it tries to find coefficients ``\Xi`` such that:
 
 ```math
-\Xi = \operatorname{argmin} ~ \left\lVert Y^{T} - \Theta(X, p, t)^{T} \Xi \right\rVert_{2} + \lambda ~ \left\lVert \Xi \right\rVert_{1}
+\Xi = \operatorname{argmin} ~ \left\{ \left\lVert Y^{T} - \Theta(X, p, t)^{T} \Xi \right\rVert_{2} + \lambda ~ \left\lVert \Xi \right\rVert_{1} \right\}
 ```
 
 where, in most cases, ``Y``is the data matrix containing the derivatives of the state data stored in ``X``. ``\Theta`` is a matrix containing candidate functions ``\xi`` over the measurements in ``X``.

--- a/docs/src/sparse_identification/sindy.md
+++ b/docs/src/sparse_identification/sindy.md
@@ -3,7 +3,7 @@
 [Sparse Identification of Nonlinear Dynamics](https://www.pnas.org/content/113/15/3932) - or SINDy - identifies the equations of motion of a system as the result of a sparse regression over a chosen basis. In particular, it tries to find coefficients ``\Xi`` such that:
 
 ```math
-\Xi = \min ~ \left\lVert Y^{T} - \Theta(X, p, t)^{T} \Xi \right\rVert_{2} + \lambda ~ \left\lVert \Xi \right\rVert_{1}
+\Xi = \operatorname{argmin} ~ \left\lVert Y^{T} - \Theta(X, p, t)^{T} \Xi \right\rVert_{2} + \lambda ~ \left\lVert \Xi \right\rVert_{1}
 ```
 
 where, in most cases, ``Y``is the data matrix containing the derivatives of the state data stored in ``X``. ``\Theta`` is a matrix containing candidate functions ``\xi`` over the measurements in ``X``.
@@ -27,10 +27,10 @@ gr()
 # Create a test problem
 function lorenz(u,p,t)
     x, y, z = u
-    ẋ = 10.0*(y - x)
-    ẏ = x*(28.0-z) - y
-    ż = x*y - (8/3)*z
-    return [ẋ, ẏ, ż]
+    ẋ = 10.0*(y - x)
+    ẏ = x*(28.0-z) - y
+    ż = x*y - (8/3)*z
+    return [ẋ, ẏ, ż]
 end
 
 u0 = [-8.0; 7.0; 27.0]


### PR DESCRIPTION
I did not change the equations, just the \min -> \argmin, but somehow git shows the equations has changed. Maybe some character encoding.