### PR TITLE
Missing variable in demo code

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -279,7 +279,7 @@ println(res) # hide
 As we can see, the [`DataDrivenSolution`](@ref) already has good metrics. Inspection of the underlying system shows that the original equations have been recovered correctly:
 
 ```@example 2
-system = result(res); # hide
+system = result(res); 
 println(system)
 ```
 


### PR DESCRIPTION
I was trying to copy-paste the demo code in [Michaelis-Menten part](https://datadriven.sciml.ai/dev/quickstart/#Implicit-Nonlinear-Dynamics-:-Michaelis-Menten). However, **the variable `system` was missing and failed to print out the result**. I suggest this line should be displayed to avoid the undefined error if the beginner uses the code from the tutorial. 

This is excellent work. Thank you for bringing these cutting-edge algorithms into practice.