### PR TITLE
Solve bug in solution.jl

### DIFF
--- a/src/solution.jl
+++ b/src/solution.jl
@@ -34,7 +34,11 @@ function DataDrivenSolution(b::AbstractBasis, p::AbstractDataDrivenProblem,
     ps = get_parameter_values(b)
     prob = remake_problem(p, p = ps)
 
-    rss = sum(abs2, get_implicit_data(prob) .- b(prob))
+    if size(b(prob)) == size(get_implicit_data(prob))
+        rss = sum(abs2, get_implicit_data(prob) .- b(prob))
+    else
+        rss = sum(abs2, get_implicit_data(prob))
+    end
 
     return DataDrivenSolution{eltype(p)}(b,
         retcode,


### PR DESCRIPTION
Proposed solution for bug in solution.jl (Fixes #514). The solution handles the case where the basis of the problem is empty which would throw the DimensionMismatch error.
