### PR TITLE
Fix 3 typos across multiple files

### DIFF
--- a/lib/DataDrivenDMD/src/type.jl
+++ b/lib/DataDrivenDMD/src/type.jl
@@ -101,7 +101,7 @@ Return the approximation of the discrete Koopman operator stored in `k`.
 """
 operator(k::Koopman{<:Any, <:Any, <:Any, true}) = __get_K(k)
 function operator(k::Koopman{<:Any, <:Any, <:Any, false})
-    throw(AssertionError("Koopman is continouos."))
+    throw(AssertionError("Koopman is continuous."))
 end
 
 """_

--- a/lib/DataDrivenLux/test/candidate.jl
+++ b/lib/DataDrivenLux/test/candidate.jl
@@ -30,7 +30,7 @@ using StableRNGs
 end
 
 # Broken for now since NaNMath.sin doesnt work with IntervalArithmetic
-# @testset "Candidate with parametes" begin
+# @testset "Candidate with parameters" begin
 #     fs = (exp,)
 #     arities = (1,)
 #     dag = LayeredDAG(1, 1, 1, arities, fs, skip = true)

--- a/src/basis/build_function.jl
+++ b/src/basis/build_function.jl
@@ -60,7 +60,7 @@ function (f::DataDrivenFunction{false, true})(u::AbstractVector, p::P, t::Number
     _apply_function(f, __EMPTY_VECTOR, u, p, t, c)
 end
 
-# With implict, without controls
+# With implicit, without controls
 function (f::DataDrivenFunction{true, false})(du::AbstractVector, u::AbstractVector, p::P,
         t::Number) where {
         P <:
@@ -100,7 +100,7 @@ function (f::DataDrivenFunction{false, true})(res::AbstractVector, u::AbstractVe
     _apply_function!(f, res, __EMPTY_VECTOR, u, p, t, c)
 end
 
-# With implict, without controls
+# With implicit, without controls
 function (f::DataDrivenFunction{true, false})(res::AbstractVector, du::AbstractVector,
         u::AbstractVector, p::P,
         t::Number) where {

--- a/src/basis/type.jl
+++ b/src/basis/type.jl
@@ -305,7 +305,7 @@ function (b::Basis{false, true})(u::AbstractVector,
     f(u, p, t, c)
 end
 
-# With implict, without controls
+# With implicit, without controls
 function (b::Basis{true, false})(du::AbstractVector, u::AbstractVector,
         p::P = parameters(b),
         t::Number = get_iv(b)) where {


### PR DESCRIPTION
## Summary\n\nThis PR fixes legitimate typos found by the typos-cli tool.\n\n## Changes\n\nFixed 3 different typos with 5 total corrections:\n\n- `implict` → `implicit` (3 occurrences)\n- `continouos` → `continuous` (1 occurrences)\n- `parametes` → `parameters` (1 occurrences)\n\n## Files Modified\n\n- lib/DataDrivenDMD/src/type.jl\n- lib/DataDrivenLux/test/candidate.jl\n- src/basis/build_function.jl\n- src/basis/type.jl\n\n🤖 Generated automatically by typos-cli analysis