### PR TITLE
Update CI to test on Julia 1, lts, and pre versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,8 @@ jobs:
           - DataDrivenLux
         version:
           - '1'
+          - 'lts'
+          - 'pre'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
## Summary
- Add 'lts' and 'pre' version testing to CI matrix
- Aligns with SciML ecosystem standards for testing on Julia 1, lts, and pre versions

## Test plan
- [x] Validate YAML syntax
- [ ] Verify CI passes on all Julia versions after merge

🤖 Generated with [Claude Code](https://claude.ai/code)