### PR TITLE
Fix isinplace detection for Basis types (#554)

### DIFF
--- a/src/basis/type.jl
+++ b/src/basis/type.jl
@@ -605,3 +605,8 @@ end
 function Base.show(io::IO, ::MIME"text/plain", b::AbstractBasis)
     Base.print(io, b)
 end
+
+# SciMLBase interface - declare whether this is an in-place function
+# IMPL=true means the basis has implicit variables and supports in-place evaluation
+# IMPL=false means the basis is out-of-place only
+DiffEqBase.isinplace(::Basis{IMPL, CTRLS}, n) where {IMPL, CTRLS} = IMPL


### PR DESCRIPTION
## Summary

This PR fixes issue #554 where creating an `ODEProblem` from a `Basis` with controls would throw a `MethodError` because SciMLBase incorrectly detected the basis as supporting in-place evaluation.

## Problem

When a `Basis{false, true}` (no implicit variables, with controls) was passed to `ODEProblem`, SciMLBase's `isinplace` check would return `true`, causing it to call the basis with a 4-argument signature `(du, u, p, t)`. However, `Basis{false, CTRLS}` only supports out-of-place signatures like `(u, p, t)` or `(u, p, t, c)`.

The `IMPL` type parameter determines whether a basis supports in-place evaluation:
- `IMPL=false`: Out-of-place only (returns result)
- `IMPL=true`: In-place (mutates first argument `du`)

## Solution

Added `DiffEqBase.isinplace` method for `Basis` types:

```julia
DiffEqBase.isinplace(::Basis{IMPL, CTRLS}, n) where {IMPL, CTRLS} = IMPL
```

This ensures `isinplace` correctly returns `false` for `Basis{false, CTRLS}` and `true` for `Basis{true, CTRLS}`, based solely on whether the basis has implicit variables.

## Testing

- All existing tests pass (252 tests)
- Verified that `isinplace` now returns correct value for both `Basis{false, false}` and `Basis{false, true}`
- Confirmed `ODEProblem` can now be created from `Basis` without the `MethodError`

Fixes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>