### PR TITLE
Fix CompatHelper cron schedule (hourly -> daily)

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -2,7 +2,7 @@ name: CompatHelper
 
 on:
   schedule:
-    - cron: '00 * * * *'
+    - cron: '00 00 * * *'
   issues:
     types: [opened, reopened]
 


### PR DESCRIPTION
## Summary
- Fix CompatHelper cron schedule from `'00 * * * *'` (every hour) to `'00 00 * * *'` (once daily at midnight UTC)

The missing hour field caused CompatHelper to run 24 times per day, creating massive workflow spam and wasting CI minutes.

## Test plan
- [ ] Verify CompatHelper runs only once per day after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)