### PR TITLE
Re-enable downgrade CI

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false  # Disabled: waiting on dependency updates. See #586
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,4 +28,4 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
-          ALLOW_RERESOLVE: false
+          allow_reresolve: true


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow, which was disabled (`if: false`, #586, "waiting on dependency updates").

The julia-actions/julia-downgrade-compat monorepo tooling problems are fixed and released in `@v2`. DataDrivenDiffEq builds and passes its test suite against the downgraded (minimal compatible) dependency versions, so the job can be re-enabled. The runtest step now uses `allow_reresolve: true` so the test environment can resolve transitive/test-only dependencies the downgrade step does not lock (the previous `ALLOW_RERESOLVE: false` was an incorrect, no-op input name).

**Verified locally on Julia 1.11** (downgrade resolve + `Pkg.build()` + `Pkg.test(; allow_reresolve=true)`, each project in its own depot):

| Project | resolve | build | test | re-resolve |
|---|---|---|---|---|
| . (DataDrivenDiffEq) | OK | OK | OK | 0 |
| lib/DataDrivenDMD | OK | OK | OK | 0 |
| lib/DataDrivenSparse | OK | OK | OK | 0 |
| lib/DataDrivenSR | OK | OK | OK | 0 |
| lib/DataDrivenLux | OK | OK | OK | 0 |

No lower-bound bumps were needed: every direct dependency resolved exactly to its declared compat floor (e.g. DataInterpolations 4.0.0, DiffEqBase 6.211.0, ModelingToolkit 11.0.0, SciMLBase 2.155.0; sublibs at DataDrivenDiffEq 1.14.0, SymbolicRegression 1.0.0, Lux 1.0.0, ComponentArrays 0.15.0). No `Project.toml` and no `julia =` compat entries are changed — the only change is the workflow file.

The workflow tests the root project only (its existing design). The four `lib/` subpackages were each verified to build and test GREEN at their declared floors as well, but are not added to this workflow's matrix because `julia-actions/julia-buildpkg` / `julia-actions/julia-runtest` have no input to target a non-root project; a GROUP-based sublib job would re-resolve sublib deps to latest and thus not exercise them at downgraded versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)