### PR TITLE
ci: add centralized sublibrary downgrade CI

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,23 @@
+name: Downgrade Sublibraries
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+jobs:
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,DataDrivenDiffEq"
+      allow-reresolve: true


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What this does

Adds `.github/workflows/DowngradeSublibraries.yml`, a thin caller workflow that invokes the centralized reusable workflow `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1`. For each `lib/*` sublibrary package it runs `julia-downgrade-compat` + `julia-buildpkg` + `julia-runtest` (project: `lib/<sub>`), catching cases where a sublibrary's `[compat]` lower bounds are broken.

Sublibraries auto-discovered (4): `DataDrivenDMD`, `DataDrivenLux`, `DataDrivenSR`, `DataDrivenSparse`. Each has a `test/runtests.jl`.

Config:
- `julia-version: lts`
- `allow-reresolve: true`
- `projects` left empty so the reusable workflow auto-discovers all `lib/*` packages with a `Project.toml`.

## Skip list

Dependencies excluded from downgrade (standard library packages + in-repo core package):

`Pkg, TOML, Statistics, LinearAlgebra, SparseArrays, InteractiveUtils, Random, Test, DataDrivenDiffEq`

`DataDrivenDiffEq` is the in-repo root package every sublibrary depends on, so it is skipped rather than downgraded.

## Note

This introduces new required-status-like CI checks (one job per sublibrary). Reviewers should expect additional checks to appear on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)