### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,12 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
@@ -30,29 +33,9 @@ jobs:
         exclude:
           - group: nopre
             version: 'pre'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,lib/DataDrivenDMD/src,lib/DataDrivenSparse/src,lib/DataDrivenSR/src,lib/DataDrivenLux/src
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          flags: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "${{ matrix.group }}"
+      coverage-directories: "src,lib/DataDrivenDMD/src,lib/DataDrivenSparse/src,lib/DataDrivenSR/src,lib/DataDrivenLux/src"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,20 +12,10 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -8,15 +7,8 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Centralize CI through SciML/.github reusable workflows (@v1)

Routes this repo's bespoke GitHub Actions workflows through the shared
[`SciML/.github`](https://github.com/SciML/.github) reusable workflows (`@v1`),
preserving the existing test matrices, coverage directories, downgrade settings,
triggers, and default branch (`master`).

### Converted workflows

| File | Was | Now (`@v1` caller) | Preserved config |
|------|-----|--------------------|------------------|
| `CI.yml` | bespoke test job | `tests.yml` | full `group` matrix (`Core`, `DataDrivenDMD`, `DataDrivenSR`, `DataDrivenSparse`, `DataDrivenLux`, `nopre`) × `version` (`1`, `lts`, `pre`), the `nopre`/`pre` `exclude`, and combined `coverage-directories` (`src` + each `lib/*/src`). Added standard `concurrency` block. |
| `Downgrade.yml` | bespoke downgrade job | `downgrade.yml` | `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`, same `master` + `paths-ignore: ['docs/**']` triggers |
| `FormatCheck.yml` | bespoke Runic action | `runic.yml` | same `push`/`pull_request` triggers (Runic is the SciML format standard) |
| `SpellCheck.yml` | bespoke typos action | `spellcheck.yml` | `pull_request` trigger |

### Already reusable (left untouched)

- `Documentation.yml` — already calls `SciML/.github/.github/workflows/documentation.yml@v1`.

### Intentionally left bespoke / local

- `TagBot.yml` — release tagging automation; no reusable equivalent.
- `CompatHelper.yml` — Compat bumping automation (with monorepo `subdirs` list); no reusable equivalent.

### Monorepo / sublibrary handling

This repo has tested sublibraries under `lib/*` (`DataDrivenDMD`, `DataDrivenSR`,
`DataDrivenSparse`, `DataDrivenLux`), but it does **not** have per-sublibrary
`CI_*.yml` files or a `DowngradeSublibraries.yml` to consolidate. The
sublibraries are exercised **through the main package's `CI.yml` `GROUP` matrix**:
`test/runtests.jl` dispatches on `GROUP`, and for a sublibrary group it `dev`s the
sublibrary and runs its `Pkg.test`, with coverage aggregated across all `lib/*/src`.

That combined-coverage, single-harness behavior is preserved by keeping the
sublibrary groups in the `tests.yml@v1` matrix. I deliberately did **not**
introduce a `SublibraryCI.yml`/`sublibrary-tests.yml@v1` caller, because that
reusable uses a different model (dependency-graph auto-discovery + isolated
per-sublibrary `test/runtests.jl` runs, with optional `test/test_groups.toml`)
that this repo's sublibraries are not currently structured for. Switching to it
would change what gets tested and how, and risks silently dropping the existing
combined coverage. Per the centralization spec ("never lose coverage; better to
under-convert than silently drop CI"), the sublibrary testing stays in the main
`tests.yml` group matrix.

### NOTE: required status check names change

Because the test/lint jobs are now defined inside the reusable workflows, the
**required-status-check names change** to the reusable jobs' names. **Branch
protection for `master` must be updated** to require the new check names once this
merges; otherwise PRs may appear to have no required checks or block on the old
(now nonexistent) check names.

---

Please ignore until reviewed by @ChrisRackauckas.
