### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the missing standard SciML centralized caller workflows for this repo.

## Workflows added
- `RunicSuggestions.yml` — auto-format suggestions on PRs (runic-suggestions-on-pr.yml@v1)
- `DependabotAutoMerge.yml` — dependabot auto-merge (dependabot-automerge.yml@v1)

(`DocPreviewCleanup.yml` already present — not duplicated.)

These are static caller files that reference the centralized reusable workflows in `SciML/.github` (`@v1`). No existing workflows were modified and no source/Project.toml changes were made.

**Please ignore this PR until reviewed by @ChrisRackauckas.** Opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
