### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,27 +14,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 jobs:
-  test:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        # Root-only test groups. The lib/* sublibraries (DataDrivenDMD, DataDrivenSR,
-        # DataDrivenSparse, DataDrivenLux) are covered by SublibraryCI.yml via the
-        # project model and must not be double-tested through the root matrix.
-        group:
-          - Core
-          - nopre
-        version:
-          - '1'
-          - 'lts'
-          - 'pre'
-        exclude:
-          - group: nopre
-            version: 'pre'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+  tests:
+    # Root-only test groups (Core, nopre) are declared in test/test_groups.toml.
+    # The lib/* sublibraries (DataDrivenDMD, DataDrivenSR, DataDrivenSparse,
+    # DataDrivenLux) are covered by SublibraryCI.yml via the project model and
+    # must not be double-tested through this root matrix.
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
       coverage-directories: "src"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

Replaces the hand-maintained `group × version` matrix in the root `CI.yml` test job with the thin `grouped-tests.yml@v1` caller. The root package's test-group matrix is now read from `test/test_groups.toml` (already present from the merged monorepo uniformization).

Before — `CI.yml` embedded:
```yaml
  test:
    name: "Tests"
    strategy:
      matrix:
        group: [Core, nopre]
        version: ['1', 'lts', 'pre']
        exclude:
          - group: nopre
            version: 'pre'
    uses: "SciML/.github/.github/workflows/tests.yml@v1"
    with:
      julia-version: "${{ matrix.version }}"
      group: "${{ matrix.group }}"
      coverage-directories: "src"
```

After:
```yaml
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    with:
      coverage-directories: "src"
    secrets: "inherit"
```

The matrix now lives in `test/test_groups.toml`:
```toml
[Core]
versions = ["lts", "1", "pre"]

[nopre]
versions = ["lts", "1"]
```

## Verified matrix match — 5/5 exact

Ran `scripts/compute_affected_sublibraries.jl . --root-matrix` from `SciML/.github@v1` and compared the emitted `(group, version)` set against the set the old workflow ran:

| group | versions |
|-------|----------|
| Core  | lts, 1, pre |
| nopre | lts, 1 (pre excluded) |

No missing, no extra. `5/5 exact`.

## Notes

- `name: CI`, the `on:` triggers, and `concurrency:` are preserved verbatim, so the branch-protection status-check identity is unchanged.
- The root `test/runtests.jl` dispatches on the default `GROUP` env var, so no `group-env-name` input is needed.
- `check-bounds` and `coverage` defaults are unchanged (`yes` / `true` in both the old `tests.yml@v1` path and `grouped-tests.yml`); only the non-default `coverage-directories: "src"` is carried over.
- The `nopre` group key is intentionally lowercase to match the literal `GROUP == "nopre"` dispatch in `runtests.jl`.
- `SublibraryCI.yml` (the `lib/*` sublibrary coverage via `sublibrary-project-tests.yml@v1`) is untouched.

Ignore until reviewed by @ChrisRackauckas.