### PR TITLE
Add QA (Aqua/JET) groups to sublibraries (SciML/.github#77)

### DIFF
--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -15,6 +15,7 @@ DataDrivenDiffEq = "1.15"
 LinearAlgebra = "1.10"
 OrdinaryDiffEq = "6, 7"
 OrdinaryDiffEqFunctionMap = "1, 2"
+Pkg = "1.10"
 SafeTestsets = "0.1"
 StableRNGs = "1"
 StatsBase = "0.34"
@@ -24,10 +25,11 @@ julia = "1.10"
 [extras]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqFunctionMap = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "StableRNGs", "StatsBase", "SafeTestsets"]
+test = ["Pkg", "Test", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "StableRNGs", "StatsBase", "SafeTestsets"]

--- a/lib/DataDrivenDMD/test/qa/Project.toml
+++ b/lib/DataDrivenDMD/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DataDrivenDMD = "3c9adf31-5280-42ff-b439-b71cc6b07807"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DataDrivenDMD = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+Test = "1"
+julia = "1.10"

--- a/lib/DataDrivenDMD/test/qa/qa.jl
+++ b/lib/DataDrivenDMD/test/qa/qa.jl
@@ -1,0 +1,13 @@
+using DataDrivenDMD
+using Aqua
+using JET
+using Test
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(DataDrivenDMD)
+    end
+    @testset "JET" begin
+        JET.test_package(DataDrivenDMD; target_defined_modules = true)
+    end
+end

--- a/lib/DataDrivenDMD/test/runtests.jl
+++ b/lib/DataDrivenDMD/test/runtests.jl
@@ -1,11 +1,17 @@
 using DataDrivenDiffEq
 using DataDrivenDMD
+using Pkg
 using SafeTestsets
 using Test
 
 @info "Finished loading packages"
 
 const GROUP = get(ENV, "DATADRIVENDIFFEQ_TEST_GROUP", get(ENV, "GROUP", "All"))
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    return Pkg.instantiate()
+end
 
 @time begin
     if GROUP == "All" || GROUP == "Core" || GROUP == "DataDrivenDMD"
@@ -20,6 +26,13 @@ const GROUP = get(ENV, "DATADRIVENDIFFEQ_TEST_GROUP", get(ENV, "GROUP", "All"))
         end
         @safetestset "Nonlinear forced" begin
             include("./Core/nonlinear_forced.jl")
+        end
+    end
+
+    if GROUP == "QA"
+        activate_qa_env()
+        @safetestset "QA" begin
+            include("qa/qa.jl")
         end
     end
 end

--- a/lib/DataDrivenDMD/test/test_groups.toml
+++ b/lib/DataDrivenDMD/test/test_groups.toml
@@ -1,4 +1,5 @@
-# Each sublibrary only defines functional ("Core") tests; there are no QA
-# (Aqua/JET/AllocCheck) suites here, so the default QA group is not declared.
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -54,6 +54,7 @@ LuxCore = "1"
 Optim = "1.7, 2"
 Optimisers = "0.3, 0.4"
 OrdinaryDiffEq = "6, 7"
+Pkg = "1.10"
 ProgressMeter = "1.7"
 Random = "1.10"
 SafeTestsets = "0.1"
@@ -67,6 +68,7 @@ julia = "1.10"
 
 [extras]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -74,4 +76,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StableRNGs", "Random", "SafeTestsets", "StatsBase", "OrdinaryDiffEq"]
+test = ["Pkg", "Test", "StableRNGs", "Random", "SafeTestsets", "StatsBase", "OrdinaryDiffEq"]

--- a/lib/DataDrivenLux/test/qa/Project.toml
+++ b/lib/DataDrivenLux/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DataDrivenLux = "47881146-99d0-492a-8425-8f2f33327637"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DataDrivenLux = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+Test = "1"
+julia = "1.10"

--- a/lib/DataDrivenLux/test/qa/qa.jl
+++ b/lib/DataDrivenLux/test/qa/qa.jl
@@ -1,0 +1,13 @@
+using DataDrivenLux
+using Aqua
+using JET
+using Test
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(DataDrivenLux)
+    end
+    @testset "JET" begin
+        JET.test_package(DataDrivenLux; target_defined_modules = true)
+    end
+end

--- a/lib/DataDrivenLux/test/runtests.jl
+++ b/lib/DataDrivenLux/test/runtests.jl
@@ -1,11 +1,17 @@
 using DataDrivenDiffEq
 using DataDrivenLux
+using Pkg
 using SafeTestsets
 using Test
 
 @info "Finished loading packages"
 
 const GROUP = get(ENV, "DATADRIVENDIFFEQ_TEST_GROUP", get(ENV, "GROUP", "All"))
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    return Pkg.instantiate()
+end
 
 @testset "DataDrivenLux" begin
     if GROUP == "All" || GROUP == "Core" || GROUP == "DataDrivenLux"
@@ -25,5 +31,12 @@ const GROUP = get(ENV, "DATADRIVENDIFFEQ_TEST_GROUP", get(ENV, "GROUP", "All"))
             @safetestset "Reinforce" include("Core/reinforce_solve.jl")
             @safetestset "CrossEntropy" include("Core/crossentropy_solve.jl")
         end
+    end
+end
+
+if GROUP == "QA"
+    activate_qa_env()
+    @safetestset "QA" begin
+        include("qa/qa.jl")
     end
 end

--- a/lib/DataDrivenLux/test/test_groups.toml
+++ b/lib/DataDrivenLux/test/test_groups.toml
@@ -1,4 +1,5 @@
-# Each sublibrary only defines functional ("Core") tests; there are no QA
-# (Aqua/JET/AllocCheck) suites here, so the default QA group is not declared.
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/DataDrivenSR/Project.toml
+++ b/lib/DataDrivenSR/Project.toml
@@ -13,6 +13,7 @@ DataDrivenDiffEq = {path = "../.."}
 
 [compat]
 DataDrivenDiffEq = "1.15"
+Pkg = "1.10"
 Reexport = "1.2"
 StableRNGs = "1"
 StatsBase = "0.34"
@@ -21,9 +22,10 @@ Test = "1.10"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StableRNGs", "StatsBase"]
+test = ["Pkg", "Test", "StableRNGs", "StatsBase"]

--- a/lib/DataDrivenSR/test/qa/Project.toml
+++ b/lib/DataDrivenSR/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DataDrivenSR = "7fed8a53-d475-4873-af3a-ba53cceea094"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DataDrivenSR = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+Test = "1"
+julia = "1.10"

--- a/lib/DataDrivenSR/test/qa/qa.jl
+++ b/lib/DataDrivenSR/test/qa/qa.jl
@@ -1,0 +1,13 @@
+using DataDrivenSR
+using Aqua
+using JET
+using Test
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(DataDrivenSR)
+    end
+    @testset "JET" begin
+        JET.test_package(DataDrivenSR; target_defined_modules = true)
+    end
+end

--- a/lib/DataDrivenSR/test/runtests.jl
+++ b/lib/DataDrivenSR/test/runtests.jl
@@ -1,12 +1,23 @@
 using DataDrivenDiffEq
 using DataDrivenSR
+using Pkg
 using Test
 using StableRNGs
 
 const GROUP = get(ENV, "DATADRIVENDIFFEQ_TEST_GROUP", get(ENV, "GROUP", "All"))
 
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    return Pkg.instantiate()
+end
+
 if GROUP == "All" || GROUP == "Core" || GROUP == "DataDrivenSR"
     @testset "Symbolic Regression" begin
         include("./Core/symbolic_regression.jl")
     end
+end
+
+if GROUP == "QA"
+    activate_qa_env()
+    include("qa/qa.jl")
 end

--- a/lib/DataDrivenSR/test/test_groups.toml
+++ b/lib/DataDrivenSR/test/test_groups.toml
@@ -1,4 +1,5 @@
-# Each sublibrary only defines functional ("Core") tests; there are no QA
-# (Aqua/JET/AllocCheck) suites here, so the default QA group is not declared.
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/DataDrivenSparse/Project.toml
+++ b/lib/DataDrivenSparse/Project.toml
@@ -16,6 +16,7 @@ DataDrivenDiffEq = {path = "../.."}
 DataDrivenDiffEq = "1.15"
 LinearAlgebra = "1.10"
 OrdinaryDiffEq = "6, 7"
+Pkg = "1.10"
 Printf = "1.10"
 Random = "1.10"
 Reexport = "1.2"
@@ -27,6 +28,7 @@ julia = "1.10"
 
 [extras]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -34,4 +36,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StableRNGs", "Random", "SafeTestsets", "StatsBase", "OrdinaryDiffEq"]
+test = ["Pkg", "Test", "StableRNGs", "Random", "SafeTestsets", "StatsBase", "OrdinaryDiffEq"]

--- a/lib/DataDrivenSparse/test/qa/Project.toml
+++ b/lib/DataDrivenSparse/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DataDrivenSparse = "5b588203-7d8b-4fab-a537-c31a7f73f46b"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DataDrivenSparse = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+Test = "1"
+julia = "1.10"

--- a/lib/DataDrivenSparse/test/qa/qa.jl
+++ b/lib/DataDrivenSparse/test/qa/qa.jl
@@ -1,0 +1,13 @@
+using DataDrivenSparse
+using Aqua
+using JET
+using Test
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(DataDrivenSparse)
+    end
+    @testset "JET" begin
+        JET.test_package(DataDrivenSparse; target_defined_modules = true)
+    end
+end

--- a/lib/DataDrivenSparse/test/runtests.jl
+++ b/lib/DataDrivenSparse/test/runtests.jl
@@ -1,8 +1,14 @@
 using DataDrivenDiffEq
 using DataDrivenSparse
+using Pkg
 using SafeTestsets
 
 const GROUP = get(ENV, "DATADRIVENDIFFEQ_TEST_GROUP", get(ENV, "GROUP", "All"))
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    return Pkg.instantiate()
+end
 
 if GROUP == "All" || GROUP == "Core" || GROUP == "DataDrivenSparse"
     @safetestset "Basic Sparse Regression" begin
@@ -19,5 +25,12 @@ if GROUP == "All" || GROUP == "Core" || GROUP == "DataDrivenSparse"
 
     @safetestset "Cartpole" begin
         include("./Core/cartpole.jl")
+    end
+end
+
+if GROUP == "QA"
+    activate_qa_env()
+    @safetestset "QA" begin
+        include("qa/qa.jl")
     end
 end

--- a/lib/DataDrivenSparse/test/test_groups.toml
+++ b/lib/DataDrivenSparse/test/test_groups.toml
@@ -1,4 +1,5 @@
-# Each sublibrary only defines functional ("Core") tests; there are no QA
-# (Aqua/JET/AllocCheck) suites here, so the default QA group is not declared.
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
Part of SciML/.github#77 (canonical QA groups for monorepo sublibraries).

Adds the canonical QA test group to each sublibrary, mirroring the OrdinaryDiffEq.jl sublibrary pattern: a `test/qa` environment with Aqua + JET (sublibrary pulled in via `[sources]` path), a `qa.jl` driver running `Aqua.test_all` and `JET.test_package(...; target_defined_modules = true)`, a QA dispatch in `test/runtests.jl` gated on `DATADRIVENDIFFEQ_TEST_GROUP == "QA"`, and a `[QA]` group declared in `test/test_groups.toml` with `versions = ["lts", "1"]` (no pre, ubuntu-only). `Pkg` is added to each sublibrary's test extras/targets with a compat entry so Aqua's `deps_compat` stays green.

Units in this batch:
- `lib/DataDrivenDMD`
- `lib/DataDrivenLux`
- `lib/DataDrivenSparse`
- `lib/DataDrivenSR`

Verification: static only (TOML parse, `Meta.parseall` on the touched Julia files, `[sources]` path resolution, Runic format check). QA findings surfaced by CI will be triaged per the established mark-broken+issue policy.

Further batches may be pushed to this branch. Ignore until reviewed by @ChrisRackauckas.