### PR TITLE
Use SciMLTesting v1.2 (explicit-args run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,7 @@ Reexport = "1.0"
 SafeTestsets = "0.1"
 SciMLBase = "2.155, 3"
 SciMLStructures = "1"
+SciMLTesting = "1"
 Setfield = "1"
 Statistics = "1"
 StatsBase = "0.32.0, 0.33, 0.34"
@@ -59,7 +60,8 @@ OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "SafeTestsets", "Pkg", "OrdinaryDiffEqTsit5"]
+test = ["Test", "Random", "SafeTestsets", "SciMLTesting", "Pkg", "OrdinaryDiffEqTsit5"]

--- a/test/nopre/Project.toml
+++ b/test/nopre/Project.toml
@@ -1,7 +1,15 @@
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DataDrivenDiffEq = {path = "../.."}
 
 [compat]
 JET = "0.9, 0.10, 0.11"
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
+Test = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,9 @@
 using SafeTestsets, Test, Pkg
+using SciMLTesting
 
 @info "Finished loading packages"
 
 const GROUP = get(ENV, "GROUP", "All")
-
-function activate_nopre_env()
-    Pkg.activate(joinpath(@__DIR__, "nopre"))
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    return Pkg.instantiate()
-end
 
 # GROUP can name a sublibrary (e.g. "DataDrivenDMD" -> Core test group) or
 # "{sublibrary}_{TEST_GROUP}" for a custom group (e.g. "DataDrivenDMD_QA").
@@ -16,21 +11,11 @@ end
 # DATADRIVENDIFFEQ_TEST_GROUP env var threads the group into the sublib's
 # own runtests.jl. CI dispatches sublibraries through SublibraryCI.yml, so
 # this branch is primarily for running a sublibrary's suite locally.
-function _detect_sublibrary_group(group, lib_dir)
-    isdir(joinpath(lib_dir, group)) && return (group, "Core")
-    for i in length(group):-1:1
-        if group[i] == '_' && isdir(joinpath(lib_dir, group[1:(i - 1)]))
-            return (group[1:(i - 1)], group[(i + 1):end])
-        end
-    end
-    return (group, "Core")
-end
-
 @time begin
     lib_dir = joinpath(dirname(@__DIR__), "lib")
-    base_group, test_group = _detect_sublibrary_group(GROUP, lib_dir)
+    base_group, test_group = detect_sublibrary_group(GROUP, lib_dir)
 
-    if isdir(joinpath(lib_dir, base_group))
+    if !isempty(base_group) && isdir(joinpath(lib_dir, base_group))
         Pkg.activate(joinpath(lib_dir, base_group))
         # On Julia < 1.11 the [sources] section is not honored; develop the
         # in-repo path dependencies (transitively) so the sublibrary tests run
@@ -64,36 +49,45 @@ end
         withenv("DATADRIVENDIFFEQ_TEST_GROUP" => test_group) do
             Pkg.test(base_group, coverage = true)
         end
-    elseif GROUP == "nopre"
-        # nopre tests are excluded from Julia pre-release versions in CI
-        # to avoid failures from upstream changes (e.g., JET type inference)
-        activate_nopre_env()
-        @safetestset "JET Static Analysis" begin
-            include("nopre/jet_tests.jl")
-        end
-    elseif GROUP == "All" || GROUP == "Core" || GROUP == "Downstream"
-        @testset "All" begin
-            @safetestset "Basis" begin
-                include("./Core/basis.jl")
-            end
-            @safetestset "Implicit Basis" begin
-                include("./Core/implicit_basis.jl")
-            end
-            @safetestset "Basis generators" begin
-                include("./Core/generators.jl")
-            end
-            @safetestset "DataDrivenProblem" begin
-                include("./Core/problem.jl")
-            end
-            @safetestset "DataDrivenSolution" begin
-                include("./Core/solution.jl")
-            end
-            @safetestset "Utilities" begin
-                include("./Core/utils.jl")
-            end
-            @safetestset "CommonSolve" begin
-                include("./Core/commonsolve.jl")
-            end
-        end
+    else
+        # nopre is a dep-adding group (JET in test/nopre/Project.toml), excluded
+        # from `All` (curated to Core) and -- as its name says -- not run on
+        # prerelease Julia (enforced by test/test_groups.toml versions).
+        run_tests(;
+            core = function ()
+                @safetestset "Basis" begin
+                    include("./Core/basis.jl")
+                end
+                @safetestset "Implicit Basis" begin
+                    include("./Core/implicit_basis.jl")
+                end
+                @safetestset "Basis generators" begin
+                    include("./Core/generators.jl")
+                end
+                @safetestset "DataDrivenProblem" begin
+                    include("./Core/problem.jl")
+                end
+                @safetestset "DataDrivenSolution" begin
+                    include("./Core/solution.jl")
+                end
+                @safetestset "Utilities" begin
+                    include("./Core/utils.jl")
+                end
+                @safetestset "CommonSolve" begin
+                    include("./Core/commonsolve.jl")
+                end
+            end,
+            groups = Dict(
+                "nopre" => (;
+                    env = joinpath(@__DIR__, "nopre"),
+                    body = function ()
+                        @safetestset "JET Static Analysis" begin
+                            include("nopre/jet_tests.jl")
+                        end
+                    end,
+                ),
+            ),
+            all = ["Core"],
+        )
     end
 end


### PR DESCRIPTION
Convert the root `test/runtests.jl` to drive SciMLTesting v1.2's `run_tests`.

This is a **monorepo** (`lib/DataDriven{DMD,Lux,SR,Sparse}`), so it uses the **explicit-args** form of `run_tests` (not folder-discovery), matching the OrdinaryDiffEq.jl / RecursiveArrayTools.jl pattern. Folder-discovery cannot express this repo's shape:

- the `nopre` group is curated **out** of `All` (`All` runs only `Core`), and
- the root file still routes a sublibrary `GROUP` (e.g. `DataDrivenDMD`, `DataDrivenSparse_QA`) to `Pkg.test` of `lib/<sublib>` for local runs (CI tests sublibs via `SublibraryCI.yml`).

Both require explicit-args mode, whose `lib_dir`/`all` knobs the folder-discovery branch returns before reaching.

Changes:
- `detect_sublibrary_group` (from SciMLTesting) replaces the hand-rolled `_detect_sublibrary_group`; the `<1.11` transitive `[sources]` develop walk + `Pkg.test(sublib, coverage=true)` sublib pre-step is kept verbatim.
- The root dispatch (Core / All / nopre) goes through `run_tests(; core = <7 Core @safetestsets>, groups = Dict("nopre" => (; env = test/nopre, body = JET)), all = ["Core"])`.
- `SciMLTesting` added to the root test deps and to `test/nopre/Project.toml` (with `SafeTestsets` + `Test`). `Pkg` is retained (still used by the sublib pre-step). `test/test_groups.toml` is unchanged.

Behavior-preserving: the exact set of tests run under each `GROUP` value (`All`/`Core`/`Downstream` -> Core; `nopre` -> JET; sublib names -> sublib `Pkg.test`) is unchanged. Verified by driving the v1.2.0 `run_tests` dispatcher over every `GROUP` value.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
