### PR TITLE
Raise DataDrivenLux Distributions floor to 0.25.123 for downgrade CI

### DIFF
--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -1,6 +1,6 @@
 name = "DataDrivenLux"
 uuid = "47881146-99d0-492a-8425-8f2f33327637"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
 
 [deps]
@@ -41,7 +41,7 @@ ComponentArrays = "0.15"
 ConcreteStructs = "0.2.3"
 DataDrivenDiffEq = "1.15"
 Distributed = "1.10"
-Distributions = "0.25"
+Distributions = "0.25.123"
 DistributionsAD = "0.6"
 DocStringExtensions = "0.9.3"
 ForwardDiff = "0.10, 1"


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

The only red lane on master is `Downgrade Sublibraries / test (lib/DataDrivenLux)`. (Root `CI`, `Sublibrary CI`, and `Downgrade` are all green post-#624.) It fails at the `Pkg.test` sandbox resolution with:

```
ERROR: Unsatisfiable requirements detected for package ModelingToolkitBase [7771a370]:
 ├─restricted by compatibility requirements with ModelingToolkit to versions: 1.30.0-1.45.0
 └─restricted by compatibility requirements with SymbolicUtils to versions: 1.0.0-1.29.1 — no versions left
```

## Root cause

- The root `DataDrivenDiffEq` compat floors `ModelingToolkit = "11.21.0"`. The lowest MTK satisfying that (`11.21.0`) requires `ModelingToolkitBase >= 1.30.0`, which requires `SymbolicUtils >= 4.23.1`.
- At `--min`, the `Distributions = "0.25"` floor in `lib/DataDrivenLux` resolves to `Distributions 0.25.88`, whose transitive constraints cap `SymbolicUtils <= 4.21.0`.
- `>= 4.23.1` vs `<= 4.21.0` → UNSAT.

Note: this is distinct from #624, which carried the release-independent code/test fixes but deliberately left the downgrade floor decision unmade.

## Fix

Raise the `lib/DataDrivenLux` floor to `Distributions = "0.25.123"`. Bisected against the binding MTK `11.21.0` floor:

| Distributions | resolves with MTK 11.21.0? |
|---|---|
| 0.25.122 | UNSAT |
| **0.25.123** | **OK** |

`0.25.123` is the lowest `0.25.x` whose transitive graph admits `SymbolicUtils >= 4.23.1`. The compat upper bound is unchanged (`0.25.123` means `>=0.25.123,<0.26`), so regular CI keeps selecting the latest `0.25.x` and is unaffected.

## Verification (local, Julia 1.10.11, clean depot)

- `julia-downgrade-compat@v2` `downgrade.jl` (Resolver.jl `--min`, `alldeps` merged mode) against `lib/DataDrivenLux`: `Successfully resolved minimal versions`.
- The `Pkg.test` sandbox resolution that previously threw the UNSAT now succeeds; it resolves `ModelingToolkitBase` and `SymbolicUtils` at versions `>=` the floors that were impossible before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)