### PR TITLE
Fix DataDrivenLux Downgrade lane: raise IntervalArithmetic (0.22.10) and Optim (2) floors

### DIFF
--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -1,6 +1,6 @@
 name = "DataDrivenLux"
 uuid = "47881146-99d0-492a-8425-8f2f33327637"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
 
 [deps]
@@ -45,13 +45,13 @@ Distributions = "0.25.123"
 DistributionsAD = "0.6"
 DocStringExtensions = "0.9.3"
 ForwardDiff = "0.10, 1"
-IntervalArithmetic = "0.22, 0.23, 1"
+IntervalArithmetic = "0.22.10, 0.23, 1"
 InverseFunctions = "0.1"
 LinearAlgebra = "1.10"
 Logging = "1.10"
 Lux = "1"
 LuxCore = "1"
-Optim = "1.7, 2"
+Optim = "2"
 Optimisers = "0.3, 0.4"
 OrdinaryDiffEq = "6, 7"
 Pkg = "1.10"


### PR DESCRIPTION
## Fix DataDrivenLux Downgrade Sublibraries lane (raise IntervalArithmetic and Optim floors)

The `Downgrade Sublibraries / test (lib/DataDrivenLux)` lane is red on master (run 28267588245, commit eb11901). The main `Downgrade` lane is green; only the DataDrivenLux sublibrary fails, and only at minimum compat versions. It resolves and builds, then fails at runtime with 5 errors. Two distinct root causes, both gated by `[compat]` lower bounds in `lib/DataDrivenLux/Project.toml`:

### 1. `IntervalArithmetic` floor `0.22` → `0.22.10` (4 errors)
`src/utils.jl` generates `safe_sin`/`safe_cos`/etc. as `f(x) = real(<f>(Complex(x)))`. During path-interval propagation, `x` is an `Interval{Float64}`, so this calls `sin(::Complex{Interval})`. Base's `sin(::Complex)` evaluates `zr == 0`, which dispatches to `==(::Interval, ::Interval)`. IntervalArithmetic `0.22.0`–`0.22.9` throw `ArgumentError("== is purposely not supported for intervals")`. `0.22.10` added the thin-interval fallback so the comparison returns a value and `sin(Complex{Interval})` works. Raise the floor to `0.22.10`.

### 2. `Optim` floor `1.7, 2` → `2` (1 `BoundsError`)
`BoundsError: attempt to access Float64 at index [2]` in `LineSearches.var"#ϕdϕ#2"`. LineSearches ≤ 7.5.x `make_ϕdϕ` does `f, g = value_gradient!(df, x_new)` and fails to unpack the scalar return of `ManifoldObjective.value_gradient!`. LineSearches 7.6.0 switched to `value_jvp!(df, x_new, s)` (a 2-tuple) and requires NLSolversBase 8. No Optim 1.x admits NLSolversBase 8 (all cap `7.9.0`), so at the Optim 1.7 floor LineSearches stays ≤ 7.5.x and the BoundsError persists. Optim 2.0.0 pulls LineSearches 7.6+ / NLSolversBase 8. Drop the `1.7` floor; require `Optim = "2"`.

Also bumps `DataDrivenLux` `0.2.4` → `0.2.5`.

### Verification (Julia 1.10 LTS, floors pinned to their minimums)
Resolved with `IntervalArithmetic` pinned to `v0.22.10` and `Optim` pinned to `v2.0.0`. The resolver co-installs IntervalArithmetic 0.22.10, Optim 2.0.0, LineSearches 7.7.1, NLSolversBase 8.0.0, then ran the `DataDrivenLux` Core test group:

```
=== KEY VERSIONS (pinned to floor) ===
LineSearches        7.7.1
IntervalArithmetic  0.22.10
Lux                 1.31.2
Optim               2.0.0
NLSolversBase       8.0.0
Distributions       0.25.129

Test Summary: | Pass  Total     Time
DataDrivenLux |   96     96  8m35.1s
```

96/96 pass, 0 fail, 0 error (was 0 pass / 5 errored on the old floors).

This PR only touches `lib/DataDrivenLux/Project.toml`. Please ignore until reviewed by @ChrisRackauckas.
