### PR TITLE
Release prep: batched version bumps for 4 packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDiffEq"
 uuid = "2445eb08-9709-466a-b3fc-47e12bd697a2"
 authors = ["Julius Martensen <julius.martensen@gmail.com>"]
-version = "1.15.2"
+version = "1.15.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDMD"
 uuid = "3c9adf31-5280-42ff-b439-b71cc6b07807"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"

--- a/lib/DataDrivenSR/Project.toml
+++ b/lib/DataDrivenSR/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSR"
 uuid = "7fed8a53-d475-4873-af3a-ba53cceea094"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"

--- a/lib/DataDrivenSparse/Project.toml
+++ b/lib/DataDrivenSparse/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSparse"
 uuid = "5b588203-7d8b-4fab-a537-c31a7f73f46b"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"


### PR DESCRIPTION
## Summary

Batched routine-release version bumps for the monorepo, per per-package scope review of unreleased changes since each package's last registered version.

| Package | Old | New | Bump | Reason |
|---|---|---|---|---|
| DataDrivenDiffEq (root) | 1.15.2 | 1.15.3 | patch | Only unreleased change outside `lib/` since 1.15.2 is the `.github/workflows/TagBot.yml` update for monorepo-aware registration triggering (`ci: use targeted monorepo TagBot`, #636). CI config only, no source/behavior change. |
| DataDrivenDMD | 0.1.4 | 0.1.5 | patch | ExplicitImports import-list cleanup (dropped an already-unused `using DataDrivenDiffEq: AbstractDataDrivenProblem` and `CommonSolve: solve!` import, both still used qualified elsewhere) and QA harness conversion (Aqua/JET -> SciMLTesting `run_qa`). No behavior change. |
| DataDrivenSR | 0.1.5 | 0.1.6 | patch | Same ExplicitImports/QA cleanup as above, plus dependency compat floor raises (`Reexport = "1.2.2"`, `SymbolicRegression = "1.13.2"`, `DataStructures` added for test). |
| DataDrivenSparse | 0.1.5 | 0.2.0 | minor | Adds a new exported public algorithm, `WyNDA` (online recursive-least-squares estimator with exponential forgetting), self-contained, documented, and unit-tested -- additive/non-breaking new API, hence minor per SemVer. Also includes two real bug fixes: `ClippedAbsoluteDeviation`'s call operator referenced an undefined variable `h` instead of `s` (`@unpack ρ = h` -> `@unpack ρ = s`), and `SparseRegressionResult.l2error` had a field-name typo (`:traineerror` -> `:trainerror`) that would throw `getfield` errors on the no-test-error code path. Plus the same ExplicitImports/QA cleanup and a `Reexport = "1.2.2"` compat floor raise. |

**DataDrivenLux is intentionally not touched in this PR.** Its `Project.toml` on master already reads `version = "0.2.5"` (bumped in #629, "Fix DataDrivenLux downgrade CI: raise IntervalArithmetic and Optim floors"), but that version was never actually registered in General -- the last registered version is 0.2.4 (no `@JuliaRegistrator` trigger comment exists on #629's merge commit, and there's no corresponding General registry PR). All changes accumulated since 0.2.4 (compat floor raises for AbstractDifferentiation/CommonSolve/ComponentArrays/ForwardDiff/IntervalArithmetic/Optim/OrdinaryDiffEq, ExplicitImports cleanup, QA harness conversion) are patch-level/non-breaking, consistent with the version already staged on master. It will be registered as-is (0.2.5) once this merges -- no Project.toml edit needed since the version field is already correct.

## Compat-floor cascade check

Dependency graph in this monorepo is a star: `DataDrivenDMD`, `DataDrivenLux`, `DataDrivenSR`, `DataDrivenSparse` each depend only on root `DataDrivenDiffEq`; root depends on none of them; no lib depends on another lib. Root's `[compat]` section declares no floors on any `DataDrivenDMD`/`DataDrivenLux`/`DataDrivenSR`/`DataDrivenSparse`. No other Project.toml in the tree references a sibling lib package outside of a package's own `test/qa/Project.toml` self-reference. Consequently no compat-floor edits are needed anywhere as a result of these bumps.

## Test plan

- [x] Scoped diffs reviewed per package against last registered commit (tree-sha / version-bump commit match verified against General registry `Versions.toml`)
- [ ] CI green on this PR (monorepo CI matrix)
- [ ] Merge, then trigger registration via commit-comment (`@JuliaRegistrator register subdir=lib/<Name>` for libs, `register()` for root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)