### PR TITLE
Repair downstream integration coverage

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,7 +22,6 @@ jobs:
         os: [ubuntu-latest]
         package:
           - {user: SciML, repo: SymbolicNumericIntegration.jl, group: All}
-          - {user: ODINN-SciML, repo: ODINN.jl, group: Core1}
 
     steps:
       - uses: actions/checkout@v7
@@ -39,20 +38,10 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            # Develop the root umbrella DataDrivenDiffEq plus every lib/* sublibrary
-            # so the downstream tests run against this checkout rather than releases.
-            Pkg.develop(PackageSpec(path="."));
-            Pkg.develop(map(path ->Pkg.PackageSpec.(;path="lib/$(path)"), readdir("./lib")));
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
+          Pkg.develop(PackageSpec(path="."))
+          Pkg.develop(PackageSpec(path="lib/DataDrivenSparse"))
+          Pkg.update()
+          Pkg.test(coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
## Summary

- remove the ODINN row, which does not depend on DataDrivenDiffEq and therefore cannot exercise this repository
- stop converting resolver errors into successful jobs
- develop the two source packages directly used by the remaining target (`DataDrivenDiffEq` and `DataDrivenSparse`) instead of every unrelated monorepo sublibrary
- update the environment before running `SymbolicNumericIntegration/All`

## Local verification

- exact workflow-shaped Julia 1.10 run against SymbolicNumericIntegration with both source packages developed — exited 0; final line: `SymbolicNumericIntegration tests passed`
- `actionlint` — passed
- `julia +1.12 -m Runic --check .` — passed
- `git diff --check` — passed

Please ignore this PR until it has been reviewed by @ChrisRackauckas.