### PR TITLE
Bump DataDrivenDiffEq subpackage versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDiffEq"
 uuid = "2445eb08-9709-466a-b3fc-47e12bd697a2"
 authors = ["Julius Martensen <julius.martensen@gmail.com>"]
-version = "1.15.3"
+version = "1.15.4"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDMD"
 uuid = "3c9adf31-5280-42ff-b439-b71cc6b07807"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"

--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -1,6 +1,6 @@
 name = "DataDrivenLux"
 uuid = "47881146-99d0-492a-8425-8f2f33327637"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
 
 [deps]

--- a/lib/DataDrivenSR/Project.toml
+++ b/lib/DataDrivenSR/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSR"
 uuid = "7fed8a53-d475-4873-af3a-ba53cceea094"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"

--- a/lib/DataDrivenSparse/Project.toml
+++ b/lib/DataDrivenSparse/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSparse"
 uuid = "5b588203-7d8b-4fab-a537-c31a7f73f46b"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"


### PR DESCRIPTION
Bumps the following subpackages so their accumulated unreleased `src/` changes can be registered:

- `DataDrivenDiffEq` v1.15.3 → **v1.15.4** (patch) — Enable rendered public API docs QA (#639) (docs/QA/compat/internal; no public API or behavior break)
- `DataDrivenDMD` v0.1.5 → **v0.1.6** (patch) — Enable rendered public API docs QA (#639) (docs/QA/compat/internal; no public API or behavior break)
- `DataDrivenLux` v0.2.5 → **v0.2.6** (patch) — Enable rendered public API docs QA (#639) (docs/QA/compat/internal; no public API or behavior break)
- `DataDrivenSR` v0.1.6 → **v0.1.7** (patch) — Enable rendered public API docs QA (#639) (docs/QA/compat/internal; no public API or behavior break)
- `DataDrivenSparse` v0.2.0 → **v0.2.1** (patch) — Enable rendered public API docs QA (#639) (docs/QA/compat/internal; no public API or behavior break)

Each bump reflects the semantic level of its diff (patch unless new public API was added). Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)