### PR TITLE
Set sequential release versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDiffEq"
 uuid = "2445eb08-9709-466a-b3fc-47e12bd697a2"
 authors = ["Julius Martensen <julius.martensen@gmail.com>"]
-version = "1.15.4"
+version = "1.16.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDMD"
 uuid = "3c9adf31-5280-42ff-b439-b71cc6b07807"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.6"
+version = "0.2.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -1,6 +1,6 @@
 name = "DataDrivenLux"
 uuid = "47881146-99d0-492a-8425-8f2f33327637"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
 
 [deps]

--- a/lib/DataDrivenSR/Project.toml
+++ b/lib/DataDrivenSR/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSR"
 uuid = "7fed8a53-d475-4873-af3a-ba53cceea094"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.7"
+version = "0.2.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenSparse/Project.toml
+++ b/lib/DataDrivenSparse/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSparse"
 uuid = "5b588203-7d8b-4fab-a537-c31a7f73f46b"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| DataDrivenDMD | 0.1.6 | 0.1.6 | 0.2.0 | minor |
| DataDrivenDiffEq | 1.15.4 | 1.15.4 | 1.16.0 | minor |
| DataDrivenLux | 0.2.6 | 0.2.6 | 0.3.0 | minor |
| DataDrivenSR | 0.1.7 | 0.1.7 | 0.2.0 | minor |
| DataDrivenSparse | 0.2.1 | 0.2.1 | 0.3.0 | minor |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total     Time / Quality Assurance |   20     20  2m44.2s / Test Summary:       | Pass  Total   Time / JET Static Analysis |   11     11  58.2s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenDMD /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:        | Pass  Total   Time / Nonlinear autonomous |   21     21  25.0s / Test Summary:    | Pass  Total   Time / Nonlinear forced |   27     27  14.4s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenDMD_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total     Time / QA            |   21     21  3m55.7s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenLux /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total      Time / DataDrivenLux |   96     96  16m54.1s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenLux_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Total  Time / DataDrivenLux |     0  0.0s / Test Summary: | Pass  Total      Time / QA            |   21     21  19m07.4s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenSR /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:       | Pass  Total     Time / Symbolic Regression |    6      6  7m48.1s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenSR_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total     Time / Quality Assurance |   21     21  8m26.7s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenSparse /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:    | Pass  Total   Time / Michaelis Menten |    9      9  28.1s / Test Summary: | Pass  Total   Time / Cartpole      |    4      4  13.3s / Testing DataDrivenDiffEq tests passed`
- `GROUP=DataDrivenSparse_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total     Time / QA            |   21     21  4m25.6s / Testing DataDrivenDiffEq tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total   Time / CommonSolve   |   59     59  14.5s / Test Summary: | Pass  Total  Time / Developer API |   15     15  5.8s / Testing DataDrivenDiffEq tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml lib/DataDrivenDMD/Project.toml lib/DataDrivenLux/Project.toml lib/DataDrivenSR/Project.toml lib/DataDrivenSparse/Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- DataDrivenDiffEq: `@JuliaRegistrator register`
- DataDrivenDMD: `@JuliaRegistrator register subdir=lib/DataDrivenDMD`
- DataDrivenLux: `@JuliaRegistrator register subdir=lib/DataDrivenLux`
- DataDrivenSR: `@JuliaRegistrator register subdir=lib/DataDrivenSR`
- DataDrivenSparse: `@JuliaRegistrator register subdir=lib/DataDrivenSparse`