### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDiffEq"
 uuid = "2445eb08-9709-466a-b3fc-47e12bd697a2"
 authors = ["Julius Martensen <julius.martensen@gmail.com>"]
-version = "1.15.4"
+version = "1.15.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDMD"
 uuid = "3c9adf31-5280-42ff-b439-b71cc6b07807"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -1,6 +1,6 @@
 name = "DataDrivenLux"
 uuid = "47881146-99d0-492a-8425-8f2f33327637"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
 
 [deps]

--- a/lib/DataDrivenSR/Project.toml
+++ b/lib/DataDrivenSR/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSR"
 uuid = "7fed8a53-d475-4873-af3a-ba53cceea094"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/DataDrivenSparse/Project.toml
+++ b/lib/DataDrivenSparse/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenSparse"
 uuid = "5b588203-7d8b-4fab-a537-c31a7f73f46b"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `DataDrivenDMD` | 0.1.6 | 0.1.7 | unreleased changes with no version bump |
| `DataDrivenDiffEq` | 1.15.4 | 1.15.5 | unreleased changes with no version bump |
| `DataDrivenLux` | 0.2.6 | 0.2.7 | unreleased changes with no version bump |
| `DataDrivenSR` | 0.1.7 | 0.1.8 | unreleased changes with no version bump |
| `DataDrivenSparse` | 0.2.1 | 0.2.2 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).