### PR TITLE
compat: declare SciMLTesting 2.10

### DIFF
--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -30,7 +30,7 @@ Statistics = "1.10"
 StatsAPI = "1"
 Symbolics = "7.18.1"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -30,9 +30,11 @@ Statistics = "1.10"
 StatsAPI = "1"
 Symbolics = "7.18.1"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqFunctionMap = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -69,7 +69,7 @@ Symbolics = "7.18.1"
 Test = "1.10"
 TransformVariables = "0.8"
 WeightInitializers = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -69,9 +69,11 @@ Symbolics = "7.18.1"
 Test = "1.10"
 TransformVariables = "0.8"
 WeightInitializers = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/lib/DataDrivenSR/Project.toml
+++ b/lib/DataDrivenSR/Project.toml
@@ -31,9 +31,11 @@ StatsAPI = "1"
 SymbolicRegression = "1.13.2"
 Symbolics = "7.18.1"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"

--- a/lib/DataDrivenSR/Project.toml
+++ b/lib/DataDrivenSR/Project.toml
@@ -31,7 +31,7 @@ StatsAPI = "1"
 SymbolicRegression = "1.13.2"
 Symbolics = "7.18.1"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/DataDrivenSparse/Project.toml
+++ b/lib/DataDrivenSparse/Project.toml
@@ -34,7 +34,7 @@ StatsAPI = "1"
 StatsBase = "0.34"
 Symbolics = "7.18.1"
 Test = "1.10"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/DataDrivenSparse/Project.toml
+++ b/lib/DataDrivenSparse/Project.toml
@@ -34,9 +34,11 @@ StatsAPI = "1"
 StatsBase = "0.34"
 Symbolics = "7.18.1"
 Test = "1.10"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"


### PR DESCRIPTION
## Summary

Declare the missing SciMLTesting compatibility bound as 2.10 and add its UUID to package test extras in the affected manifest(s):

- lib/DataDrivenDMD/Project.toml
- lib/DataDrivenLux/Project.toml
- lib/DataDrivenSR/Project.toml
- lib/DataDrivenSparse/Project.toml

This PR is manifest-only. It does not change source behavior, tests, public APIs, or documentation.

## Verification

- Julia TOML.parsefile passed for all TOML files in the 20-repository batch.
- Pkg.Types.read_project passed for all 32 changed manifests, including the new compat and extras entries.
- git diff --check passed for all 20 repositories.
- typos passed on all changed TOML files.
- Runic was not run because the diff contains TOML only.
- No test suite was run because no source or test files changed.

Please ignore this draft until reviewed by @ChrisRackauckas.