### PR TITLE
docs: add DataDrivenSR interface example

### DIFF
--- a/lib/DataDrivenSR/src/DataDrivenSR.jl
+++ b/lib/DataDrivenSR/src/DataDrivenSR.jl
@@ -25,6 +25,17 @@ Sorts the operators stored in `functions` into unary and binary operators on con
 # Fields
 
 $(FIELDS)
+
+# Examples
+
+```julia
+using DataDrivenSR
+using SymbolicRegression: Options
+
+algorithm = EQSearch(
+    eq_options = Options(binary_operators = [+, *], unary_operators = [sin])
+)
+```
 """
 @with_kw struct EQSearch <: AbstractDataDrivenAlgorithm
     "Optionally weight the loss for each y by this value (same shape as y)"

--- a/lib/DataDrivenSR/test/Core/developer_api.jl
+++ b/lib/DataDrivenSR/test/Core/developer_api.jl
@@ -1,0 +1,18 @@
+using DataDrivenDiffEq
+using DataDrivenSR
+using Symbolics: @variables
+using Test
+
+@testset "AbstractDataDrivenAlgorithm" begin
+    @variables x
+    basis = Basis([x], [x])
+    X = reshape([1.0, 2.0, 3.0], 1, :)
+    Y = 2 .* X
+    problem = DirectDataDrivenProblem(X, Y)
+    algorithm = EQSearch()
+
+    @test algorithm isa AbstractDataDrivenAlgorithm
+    inputs, targets = DataDrivenDiffEq.get_fit_targets(algorithm, problem, basis)
+    @test inputs == X
+    @test targets == Y
+end

--- a/lib/DataDrivenSR/test/Core/developer_api.jl
+++ b/lib/DataDrivenSR/test/Core/developer_api.jl
@@ -11,7 +11,7 @@ using Test
     problem = DirectDataDrivenProblem(X, Y)
     algorithm = EQSearch()
 
-    @test algorithm isa AbstractDataDrivenAlgorithm
+    @test algorithm isa DataDrivenDiffEq.AbstractDataDrivenAlgorithm
     inputs, targets = DataDrivenDiffEq.get_fit_targets(algorithm, problem, basis)
     @test inputs == X
     @test targets == Y

--- a/lib/DataDrivenSR/test/runtests.jl
+++ b/lib/DataDrivenSR/test/runtests.jl
@@ -18,6 +18,10 @@ function activate_qa_env()
 end
 
 if GROUP == "All" || GROUP == "Core" || GROUP == "DataDrivenSR"
+    @testset "Developer interface" begin
+        include("./Core/developer_api.jl")
+    end
+
     @testset "Symbolic Regression" begin
         include("./Core/symbolic_regression.jl")
     end


### PR DESCRIPTION
This is a focused follow-up to the merged SciMLTesting compat rollout in #650. It adds a SciMLStyle usage example to EQSearch and a generic AbstractDataDrivenAlgorithm interface test for DataDrivenSR. No compat-only or solver behavior changes are included.\n\nPlease ignore this draft until reviewed by @ChrisRackauckas.\n\nVerification:\n- Runic format comparison: clean for modified Julia files.\n- typos: clean for changed source and test files.\n- git diff --check: clean.\n- The prior merged-compat QA run for DataDrivenSR was 21/21.\n- The targeted Julia Core command was stopped after about five minutes while compiling the dependency graph because another local Catalyst QA process held shared precompile locks; it did not reach a test result.