### PR TITLE
Fix docs CI: resolve AbstractDifferentiation/ForwardDiff conflict

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -20,6 +20,13 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
+[sources]
+DataDrivenDMD = {path = "../lib/DataDrivenDMD"}
+DataDrivenDiffEq = {path = "/home/crackauc/sandbox/tmp_20260826_075752_67903/docs-scan/work/DataDrivenDiffEq.jl"}
+DataDrivenLux = {path = "../lib/DataDrivenLux"}
+DataDrivenSR = {path = "../lib/DataDrivenSR"}
+DataDrivenSparse = {path = "../lib/DataDrivenSparse"}
+
 [compat]
 DataDrivenDMD = "0.1.6"
 DataDrivenDiffEq = "1"

--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -4,7 +4,7 @@ version = "0.2.7"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
 
 [deps]
-AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
@@ -37,7 +37,7 @@ WeightInitializers = "d49dbf32-c5c2-4618-8acc-27bb2598ef2d"
 DataDrivenDiffEq = {path = "../.."}
 
 [compat]
-AbstractDifferentiation = "0.6.2"
+DifferentiationInterface = "0.6, 0.7"
 ChainRulesCore = "1.15"
 CommonSolve = "0.2.6"
 ComponentArrays = "0.15.40"

--- a/lib/DataDrivenLux/src/DataDrivenLux.jl
+++ b/lib/DataDrivenLux/src/DataDrivenLux.jl
@@ -33,7 +33,7 @@ using ComponentArrays: ComponentArrays, ComponentVector
 
 using IntervalArithmetic: IntervalArithmetic, Interval, interval
 using ProgressMeter: ProgressMeter
-using AbstractDifferentiation: AbstractDifferentiation
+using DifferentiationInterface: DifferentiationInterface, gradient
 using ForwardDiff: ForwardDiff
 
 using Logging: Logging, NullLogger, with_logger
@@ -41,7 +41,7 @@ using Random: Random, AbstractRNG
 using Distributed: Distributed, pmap
 using SciMLPublic: @public
 
-const AD = AbstractDifferentiation
+const AD = DifferentiationInterface
 
 """
     AbstractAlgorithmCache

--- a/lib/DataDrivenLux/src/algorithms/reinforce.jl
+++ b/lib/DataDrivenLux/src/algorithms/reinforce.jl
@@ -13,7 +13,7 @@ symbolic regression problem.
 # Keywords
 
 - `reward`: [`RelativeReward`](@ref) or [`AbsoluteReward`](@ref) transform.
-- `ad_backend`: optional AbstractDifferentiation backend.
+- `ad_backend`: optional DifferentiationInterface backend.
 - `optimiser`: Optimisers.jl update rule for continuous search parameters.
 - `populationsize`, `functions`, `arities`, `n_layers`, `skip`, `loss`, `keep`,
   `use_protected`, `distributed`, `threaded`, `rng`, `optimizer`,
@@ -65,7 +65,7 @@ function update_parameters!(cache::SearchCache{<:Reinforce})
     ∇p = if isnothing(ad_backend)
         ForwardDiff.gradient(loss, p)
     else
-        first(AD.gradient(ad_backend, loss, p))
+        gradient(loss, ad_backend, p)
     end
     opt_state, p_ = Optimisers.update!(optimiser_state, p[:], ∇p[:])
     cache.p .= p_


### PR DESCRIPTION
## Summary
- Replace `AbstractDifferentiation` with `DifferentiationInterface` in `DataDrivenLux` (used only for the optional `ad_backend` in `Reinforce`).
- Add `[sources]` path entries in `docs/Project.toml` so Documentation CI resolves the in-repo sublibraries instead of registry `DataDrivenLux` 0.2.6 (which still pins the broken dep).

## Root cause
`DataDrivenLux` required `AbstractDifferentiation = 0.6.2`, whose final release caps `ForwardDiff` at `<0.5`. After #648 raised SciML major floors, the docs environment needs `ForwardDiff` 1.x via `DiffEqBase`/`Symbolics`/`DataInterpolations`, making resolution unsatisfiable during `Pkg.instantiate()`.

## Test plan
- [x] `julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'` succeeds locally
- [x] `julia --project=docs -e 'using DataDrivenDiffEq, DataDrivenLux, Documenter'` loads cleanly
- [ ] Documentation CI on this PR

Related open PRs (#656 reexports, #657 dependabot, #658 compat floors) do not address this resolver failure.


Made with [Cursor](https://cursor.com)