### PR TITLE
Handle despecialized parameters in DataDrivenProblem

### DIFF
--- a/src/DataDrivenDiffEq.jl
+++ b/src/DataDrivenDiffEq.jl
@@ -10,8 +10,8 @@ using SciMLBase: SciMLBase, isdiscrete
 using CommonSolve: CommonSolve, init
 using Reexport: @reexport
 import ModelingToolkitBase
-using ModelingToolkitBase: @parameters, AbstractSystem, MTKParameters, equations, get_iv,
-    get_observed, independent_variable, observed, parameters, unknowns
+using ModelingToolkitBase: @parameters, AbstractSystem, equations, get_iv, get_observed,
+    independent_variable, observed, parameters, unknowns
 
 using Parameters: @unpack, @with_kw
 using Setfield: @set!

--- a/src/problem/type.jl
+++ b/src/problem/type.jl
@@ -185,14 +185,14 @@ function DataDrivenProblem(
         DX::AbstractMatrix = Array{eltype(X)}(undef, 0, 0),
         Y::AbstractMatrix = Array{eltype(X)}(undef, 0, 0),
         U::F = Array{eltype(X)}(undef, 0, 0),
-        p::Union{AbstractVector, MTKParameters} = Array{eltype(X)}(undef, 0),
+        p = Array{eltype(X)}(undef, 0),
         probtype = nothing,
         kwargs...
     ) where {F <: Union{AbstractMatrix, Function}}
-    if SS.isscimlstructure(p)
-        _p, _, _ = SS.canonicalize(SS.Tunable(), p)
-    else
-        _p = p
+    _p = isdefined(SciMLBase, :unwrap_parameters) ?
+        getproperty(SciMLBase, :unwrap_parameters)(p) : p
+    if SS.isscimlstructure(_p)
+        _p, _, _ = SS.canonicalize(SS.Tunable(), _p)
     end
     return DataDrivenProblem(probtype, X, t, DX, Y, U, _p; kwargs...)
 end

--- a/src/problem/type.jl
+++ b/src/problem/type.jl
@@ -189,8 +189,10 @@ function DataDrivenProblem(
         probtype = nothing,
         kwargs...
     ) where {F <: Union{AbstractMatrix, Function}}
-    _p = isdefined(SciMLBase, :unwrap_parameters) ?
-        getproperty(SciMLBase, :unwrap_parameters)(p) : p
+    _p = p
+    if isdefined(SciMLBase, :unwrap_parameters)
+        _p = getproperty(SciMLBase, :unwrap_parameters)(_p)
+    end
     if SS.isscimlstructure(_p)
         _p, _, _ = SS.canonicalize(SS.Tunable(), _p)
     end

--- a/test/Core/problem.jl
+++ b/test/Core/problem.jl
@@ -1,6 +1,7 @@
 using DataDrivenDiffEq, Test
 using LinearAlgebra
 using ModelingToolkit
+import SciMLBase
 
 # Generate some test data
 t = collect(0:0.1:5.0)
@@ -47,6 +48,11 @@ end
     @test is_parametrized(p6)
     @test isequal(p6.p, p)
     @test has_timepoints(p4)
+
+    if isdefined(SciMLBase, :DespecializedParameters)
+        wrapped_p = getproperty(SciMLBase, :DespecializedParameters)(p)
+        @test isequal(ContinuousDataDrivenProblem(X, DX; p = wrapped_p).p, p)
+    end
 end
 
 @testset "DirectProblem" begin


### PR DESCRIPTION
Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

`DataDrivenProblem` now accepts SciMLBase's despecialized parameter wrapper, unwraps it through the public SciMLBase API when available, and then canonicalizes the underlying parameter object. The implementation uses separate `if` blocks so the unwrap-then-structure-check ordering is explicit. This removes the narrow keyword type restriction that rejected parameters produced by current SciMLBase/ModelingToolkit integrations. The stale direct `MTKParameters` import is no longer needed.

A Core test directly exercises `SciMLBase.DespecializedParameters` when that API is available.

## Verification

On the unfixed code, the new test failed with:

```text
TypeError: in keyword argument p, expected Union{MTKParameters, AbstractVector}, got a value of type SciMLBase.DespecializedParameters
```

On this branch:

```text
GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Basis | 50 passed
Implicit | 14 passed
Generators | 22 passed
DataDrivenProblem | 79 passed
DataDrivenSolution | 22 passed
Utilities | 32 passed
CommonSolve Interface | 59 passed
Developer Interface | 33 passed
Testing DataDrivenDiffEq tests passed

GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Quality Assurance | 96 passed
JET Static Analysis | 11 passed
Testing DataDrivenDiffEq tests passed
```

Runic, `typos`, and `git diff --check` completed with exit code 0 on the changed files.

## Not verified

The complete docs build was not rerun for this focused Core fix. No public API was added or changed.

No SciMLBase lower-bound bump is needed. `DespecializedParameters` and the public `unwrap_parameters` helper were introduced together in SciMLBase 3.46.0; both the implementation and test are feature-gated, so earlier SciMLBase 3 releases retain the pre-wrapper path.

## Links

- SciMLBase wrapper introduction: https://github.com/SciML/SciMLBase.jl/commit/a932b024aa18eee6550e24182ac229eb32d2b343
- SciMLBase follow-up: https://github.com/SciML/SciMLBase.jl/commit/60ae0fbd1b73713d3edb525837d954d672372e89
- ModelingToolkit integration change: https://github.com/SciML/ModelingToolkit.jl/commit/55856687b1c25e1b767d6834589cba26dbd0ead6

🤖 Generated with OpenAI Codex
