### PR TITLE
Use a portable local source in the docs environment

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -22,7 +22,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [sources]
 DataDrivenDMD = {path = "../lib/DataDrivenDMD"}
-DataDrivenDiffEq = {path = "/home/crackauc/sandbox/tmp_20260826_075752_67903/docs-scan/work/DataDrivenDiffEq.jl"}
+DataDrivenDiffEq = {path = ".."}
 DataDrivenLux = {path = "../lib/DataDrivenLux"}
 DataDrivenSR = {path = "../lib/DataDrivenSR"}
 DataDrivenSparse = {path = "../lib/DataDrivenSparse"}


### PR DESCRIPTION
Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

The docs environment now resolves `DataDrivenDiffEq` with `path = ".."` instead of an absolute path to one machine's temporary checkout. This makes `Pkg.instantiate()` portable across local checkouts and CI runners.

## Verification

With the original absolute source path hidden in a Bubblewrap mount namespace, docs instantiation exited 1 because the expected package path did not exist. With this change, the same isolated check completed successfully:

```text
julia +1.12 --project=docs -e 'using Pkg; Pkg.instantiate(); println("DOCS_INSTANTIATE_OK")'
DataDrivenDiffEq v1.15.5 `..`
265 dependencies successfully precompiled
DOCS_INSTANTIATE_OK

julia +1.12 --project=docs -e 'using DataDrivenDiffEq; println("PORTABLE_DOCS_SOURCE_OK ", pathof(DataDrivenDiffEq))'
PORTABLE_DOCS_SOURCE_OK .../DataDrivenDiffEq.jl/src/DataDrivenDiffEq.jl
```

`typos` and `git diff --check` completed with exit code 0.

## Not verified

The full docs build progressed past environment instantiation and then hit the separate `DespecializedParameters` regression on master. That regression is addressed in a separate draft PR.

## Links

- Change that introduced the absolute source path: https://github.com/SciML/DataDrivenDiffEq.jl/pull/659
- Introducing commit: https://github.com/SciML/DataDrivenDiffEq.jl/commit/b4e44ed67118b56ef92aafcf41166f99063f1c80

🤖 Generated with OpenAI Codex
