### PR TITLE
Develop all DataDrivenDiffEq lib/* in Downstream CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -39,7 +39,11 @@ jobs:
         run: |
           using Pkg
           Pkg.develop(PackageSpec(path="."))
-          Pkg.develop(PackageSpec(path="lib/DataDrivenSparse"))
+          if isdir("lib")
+              Pkg.develop(map(name -> PackageSpec(; path = joinpath("lib", name)),
+                              filter(name -> isfile(joinpath("lib", name, "Project.toml")),
+                                     readdir("lib"))))
+          end
           Pkg.update()
           Pkg.test(coverage=true)
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
Workflow-only. The inline IntegrationTest job `Pkg.develop`'d `lib/DataDrivenSparse` only. The repo also ships `DataDrivenDMD`, `DataDrivenLux`, and `DataDrivenSR`.

## What changed

Develop every `lib/*/Project.toml`, same pattern as DiffEqProblemLibrary. Downstream remains SymbolicNumericIntegration `All`.

## Verification

Post-change YAML still has `group: All` (SciMLTesting reserved / SymbolicNumericIntegration Core+QA). The Julia step `readdir("lib")` for `Project.toml` dirs.

Did not wait for GitHub Actions.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)