### PR TITLE
Fix DataDrivenLux RandomSearch interval(extrema) for IA 1.x

### DIFF
--- a/lib/DataDrivenLux/test/Core/randomsearch_solve.jl
+++ b/lib/DataDrivenLux/test/Core/randomsearch_solve.jl
@@ -34,7 +34,7 @@ for (data, _interval) in zip(
         (X, Y, 1:size(X, 2)),
         (dummy_dataset.x_intervals[1], dummy_dataset.y_intervals[1], dummy_dataset.t_interval)
     )
-    @test isequal_interval(_interval, interval(extrema(data)))
+    @test isequal_interval(_interval, interval(extrema(data)...))
 end
 
 # We have 1 Choices in the first layer, 2 in the last


### PR DESCRIPTION
## Summary
- Root Downgrade is green; Downgrade Sublibraries / DataDrivenLux still fails RandomSearch with `_interval_infsup(::Type{Any}, ::Tuple, ...)`.
- Splat `interval(extrema(data)...)` in the remaining test (same IA 1.x issue as #665 Dataset fix).

Ignore until reviewed by @ChrisRackauckas.

## Test plan
- [ ] downgrade-sublibraries / test (lib/DataDrivenLux) passes


Made with [Cursor](https://cursor.com)