### PR TITLE
Format for Runic v1.10

### DIFF
--- a/lib/DataDrivenLux/src/lux/layer.jl
+++ b/lib/DataDrivenLux/src/lux/layer.jl
@@ -73,10 +73,10 @@ end
     st_symbols = [gensym() for _ in 1:N]
     calls = [
         :(
-                $(st_symbols[i]) = get_loglikelihood(
-                    layers.$(fields[i]), ps.$(fields[i]), st.$(fields[i])
-                )
-            ) for i in 1:N
+            $(st_symbols[i]) = get_loglikelihood(
+                layers.$(fields[i]), ps.$(fields[i]), st.$(fields[i])
+            )
+        ) for i in 1:N
     ]
     push!(calls, :(st = NamedTuple{$fields}((($(Tuple(st_symbols)...),)))))
     return Expr(:block, calls...)
@@ -89,10 +89,10 @@ end
     st_symbols = [gensym() for _ in 1:N]
     calls = [
         :(
-                $(st_symbols[i]) = get_configuration(
-                    layers.$(fields[i]), ps.$(fields[i]), st.$(fields[i])
-                )
-            ) for i in 1:N
+            $(st_symbols[i]) = get_configuration(
+                layers.$(fields[i]), ps.$(fields[i]), st.$(fields[i])
+            )
+        ) for i in 1:N
     ]
     push!(calls, :(st = NamedTuple{$fields}((($(Tuple(st_symbols)...),)))))
     return Expr(:block, calls...)


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `defc0aa7ae92`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos lib/DataDrivenLux/src/lux/layer.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Quality Assurance | 96 pass, 96 total
JET Static Analysis | 11 pass, 11 total
Testing DataDrivenDiffEq tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Basis | 50 pass, 50 total
Implicit Basis | 14 pass, 14 total
Basis generators | 22 pass, 22 total
DataDrivenProblem | 79 pass, 79 total
DataDrivenSolution | 22 pass, 22 total
Utilities | 32 pass, 32 total
CommonSolve | 59 pass, 59 total
Developer API | 33 pass, 33 total
Testing DataDrivenDiffEq tests passed
$ GROUP=DataDrivenLux_Core ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Developer interface | 6 pass, 6 total
DataDrivenLux | 99 pass, 99 total
Testing DataDrivenLux tests passed
```

`GROUP=DataDrivenLux_QA` fails identically on this branch and clean base: 20 checks
pass and one ExplicitImports check errors because `Optim.converged` and
`ForwardDiff.gradient` are not public API. This is independent of the formatted file;
the separate clean-base fix, including passing QA and Core evidence, is
https://github.com/SciML/DataDrivenDiffEq.jl/pull/671.

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- The repository docs environment does not currently resolve on clean base because its DataDrivenLux compatibility excludes the tagged version. The independent clean-base fix, including a successful local docs build, is https://github.com/SciML/DataDrivenDiffEq.jl/pull/670.
- The DataDrivenLux QA group remains blocked on the independent clean-base public-API regression fixed by https://github.com/SciML/DataDrivenDiffEq.jl/pull/671.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the sublibrary source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
