### PR TITLE
Fix DataDrivenLux docs compatibility for 0.3

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -30,7 +30,7 @@ DataDrivenSparse = {path = "../lib/DataDrivenSparse"}
 [compat]
 DataDrivenDMD = "0.1.6"
 DataDrivenDiffEq = "1"
-DataDrivenLux = "0.2.6"
+DataDrivenLux = "0.3"
 DataDrivenSR = "0.1.7"
 DataDrivenSparse = "0.2.1"
 Documenter = "1"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

DataDrivenLux was released as 0.3.0, but the documentation environment still constrained it to the 0.2 series. That made the docs environment impossible to resolve. This updates the docs-only compatibility entry to the current 0.3 series; it does not change package code or public API.

The regression bisects to https://github.com/SciML/DataDrivenDiffEq.jl/commit/5a9f9d39671920d4e38a477d6399bb89e05085fa, which changed the local DataDrivenLux version from 0.2.7 to 0.3.0 without updating `docs/Project.toml`.

## Failing before

On clean master `defc0aa7ae9201cf4114a152364d657851f44a60`:

```text
$ julia +1.12 --color=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
Resolving package versions...
ERROR: empty intersection between DataDrivenLux@0.3.0 and project compatibility 0.2.6 - 0.2
exit=1
```

The same failure is visible in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33144023664.

## Passing after

```text
$ julia +1.12 --color=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
DataDrivenLux v0.3.0 `../lib/DataDrivenLux`
exit=0

$ julia +1.12 --color=no --project=docs docs/make.jl
[ Info: Automatic `version="1.16.0"` for inventory from ../Project.toml
exit=0

$ GROUP=QA julia +release --color=no --project -e 'using Pkg; Pkg.test()'
Quality Assurance | 96  96
JET Static Analysis | 11  11
Testing DataDrivenDiffEq tests passed
exit=0

$ GROUP=All julia +release --color=no --project -e 'using Pkg; Pkg.test()'
Basis 50/50; Implicit Basis 14/14; Basis generators 22/22;
DataDrivenProblem 79/79; DataDrivenSolution 22/22; Utilities 32/32;
CommonSolve 59/59; Developer API 33/33
Testing DataDrivenDiffEq tests passed
exit=0

$ git diff --check
exit=0

$ typos docs/Project.toml
exit=0
```

## Not verified / known base state

GPU, downstream, downgrade, and prerelease-Julia jobs were not run locally. Full-repository Runic 1.10 checking still reports the pre-existing `layer.jl` generator-indentation change on master; that mechanical update is intentionally separate in https://github.com/SciML/DataDrivenDiffEq.jl/pull/669.

## Reviewer note

The only judgment call is narrowing the docs entry to `DataDrivenLux = "0.3"` instead of retaining the obsolete 0.2 series. The docs environment develops the in-tree subpackage and therefore must admit its current version.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
