### PR TITLE
Fix DataDrivenLux public API accesses

### DIFF
--- a/lib/DataDrivenLux/Project.toml
+++ b/lib/DataDrivenLux/Project.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -37,6 +38,7 @@ WeightInitializers = "d49dbf32-c5c2-4618-8acc-27bb2598ef2d"
 DataDrivenDiffEq = {path = "../.."}
 
 [compat]
+ADTypes = "1"
 DifferentiationInterface = "0.6, 0.7"
 ChainRulesCore = "1.15"
 CommonSolve = "0.2.6"

--- a/lib/DataDrivenLux/src/DataDrivenLux.jl
+++ b/lib/DataDrivenLux/src/DataDrivenLux.jl
@@ -33,6 +33,7 @@ using ComponentArrays: ComponentArrays, ComponentVector
 
 using IntervalArithmetic: IntervalArithmetic, Interval, interval
 using ProgressMeter: ProgressMeter
+using ADTypes: AutoForwardDiff
 using DifferentiationInterface: DifferentiationInterface, gradient
 using ForwardDiff: ForwardDiff
 

--- a/lib/DataDrivenLux/src/algorithms/reinforce.jl
+++ b/lib/DataDrivenLux/src/algorithms/reinforce.jl
@@ -63,7 +63,7 @@ function update_parameters!(cache::SearchCache{<:Reinforce})
 
     loss = p -> reinforce_loss(candidates[keeps], p, alg)
     ∇p = if isnothing(ad_backend)
-        ForwardDiff.gradient(loss, p)
+        gradient(loss, AutoForwardDiff(), p)
     else
         gradient(loss, ad_backend, p)
     end

--- a/lib/DataDrivenLux/src/caches/candidate.jl
+++ b/lib/DataDrivenLux/src/caches/candidate.jl
@@ -181,6 +181,19 @@ end
 
 initial_values(c::Candidate) = ComponentVector(; c.scales, c.parameters)
 
+function _optim_converged(result)
+    status = result.stopped_by
+    convergence_reached = status.x_converged || status.f_converged || status.g_converged
+    x_isfinite = isfinite(result.x_abschange) || isnan(result.x_relchange)
+    f_isfinite = if status.iterations > 0
+        isfinite(result.f_abschange) || isnan(result.f_relchange)
+    else
+        true
+    end
+    g_isfinite = isfinite(result.g_residual)
+    return convergence_reached && all((x_isfinite, f_isfinite, g_isfinite))
+end
+
 function optimize_candidate!(
         c::Candidate, dataset::Dataset{T}, ps = c.ps; optimizer = Optim.LBFGS(),
         options = nothing
@@ -199,7 +212,7 @@ function optimize_candidate!(
                 return Optim.optimize(loss, p_init, optimizer, options)
             end
 
-            if Optim.converged(res)
+            if _optim_converged(res)
                 c.outgoing_path .= path
                 @set! c.st = st
                 c.parameters .= res.minimizer.parameters

--- a/lib/DataDrivenLux/test/Core/candidate.jl
+++ b/lib/DataDrivenLux/test/Core/candidate.jl
@@ -4,11 +4,22 @@ using IntervalArithmetic
 using Distributions
 using Random
 using Lux
+using Optim
 using Test
 using StableRNGs
 using StatsAPI: nobs, r2, rss
 using Symbolics: @variables
 using ModelingToolkitBase: @parameters
+
+@testset "Optim convergence" begin
+    result = Optim.optimize(x -> sum(abs2, x), ones(2), Optim.LBFGS())
+    @test DataDrivenLux._optim_converged(result)
+
+    result = Optim.optimize(
+        x -> sum(abs2, x), ones(2), Optim.LBFGS(), Optim.Options(iterations = 0)
+    )
+    @test !DataDrivenLux._optim_converged(result)
+end
 
 @testset "Candidate without choice" begin
     fs = (x -> x^2,)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

DataDrivenLux's strict QA fails on master because it calls two non-public dependency functions: `Optim.converged` and `ForwardDiff.gradient`. This change routes the default reinforcement gradient through the public DifferentiationInterface API with an ADTypes-owned `AutoForwardDiff` backend, and reproduces Optim's small convergence predicate locally instead of binding to its non-public helper.

ADTypes becomes a direct dependency because DataDrivenLux now imports the backend type from its declaring package. ADTypes is MIT-licensed, matching this repository's permissive license, and was already present transitively.

The clean-master failure was reproduced at `defc0aa7ae9201cf4114a152364d657851f44a60`. Automated bisection found that strict QA began exposing the pre-existing Optim access in https://github.com/SciML/DataDrivenDiffEq.jl/commit/68af083af27a370216ac848f770fd7e9e6048b36, while the ForwardDiff qualified access was introduced in https://github.com/SciML/DataDrivenDiffEq.jl/commit/775590c48f7ffc66b9679798cf7a9b20049e1df0.

## Failing before

```console
$ GROUP=DataDrivenLux_QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary:                                  | Pass  Error  Total
QA                                            |   20      1     21
Non-public qualified accesses:
  Optim.converged at lib/DataDrivenLux/src/caches/candidate.jl:202
  ForwardDiff.gradient at lib/DataDrivenLux/src/algorithms/reinforce.jl:66
ERROR: Package DataDrivenDiffEq errored during testing
```

Exit status: 1.

## Passing after

```console
$ GROUP=DataDrivenLux_QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   21     21  5m36.2s
Testing DataDrivenLux tests passed
Testing DataDrivenDiffEq tests passed

$ GROUP=DataDrivenLux_Core julia --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
DataDrivenLux |  101    101  15m49.7s
Testing DataDrivenLux tests passed
Testing DataDrivenDiffEq tests passed

$ julia --project=.runic-env -m Runic --check lib/DataDrivenLux/src/DataDrivenLux.jl lib/DataDrivenLux/src/algorithms/reinforce.jl lib/DataDrivenLux/src/caches/candidate.jl lib/DataDrivenLux/test/Core/candidate.jl
# exit 0; Runic 1.10.0

$ git diff --unified=0 | typos -
# exit 0; typos-cli 1.47.0

$ git diff --check
# exit 0
```

The whole-repository Runic 1.10.0 check still exits 1 only for the pre-existing generator indentation in `lib/DataDrivenLux/src/lux/layer.jl`; that mechanical change is isolated in https://github.com/SciML/DataDrivenDiffEq.jl/pull/669 and is intentionally not mixed into this bug fix.

PR CI also reproduces master's documentation resolver failure (`empty intersection between DataDrivenLux@0.3.0 and project compatibility 0.2.6 - 0.2`) in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33297826918. That independent base failure is fixed and locally validated in https://github.com/SciML/DataDrivenDiffEq.jl/pull/670.

Post-push CI passes DataDrivenLux QA and Core on Julia LTS/1/pre in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33297826975, DataDrivenLux downgrade in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33297826760, root QA/Core in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33297827134, root downgrade in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33297826882, and downstream SymbolicNumericIntegration in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33297826568.

## Not verified

- Documentation was not rebuilt because this changes no public DataDrivenLux API, docstring, or documentation source.
- GPU, downstream, downgrade, and Julia pre jobs were not run locally.

## Reviewer judgment call

The local `_optim_converged` predicate mirrors Optim's current convergence logic because Optim does not declare its helper public. If Optim later provides a public success predicate, DataDrivenLux should switch to it.

🤖 Generated with Codex CLI 0.151.0 (model: unknown). Session: local session ID `01a04fa1-cfe0-7260-b416-72fe8a15d17d`
