### PR TITLE
Support DataInterpolations 10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.16.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+CurveFit = "5a033b19-8c74-5913-a970-47c3779ef25c"
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -30,7 +31,8 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 CommonSolve = "0.2"
-DataInterpolations = "9.0"
+CurveFit = "1.8.1"
+DataInterpolations = "9.2, 10"
 DataStructures = "0.19"
 DiffEqBase = "7"
 DocStringExtensions = "0.9"

--- a/docs/src/reexports.md
+++ b/docs/src/reexports.md
@@ -84,7 +84,9 @@ Owned and documented by
 [DataInterpolations](https://docs.sciml.ai/DataInterpolations/stable/). The rest of
 the DataInterpolations surface — the remaining interpolation types, the derivative and
 integral interfaces, and the caching options — must be imported from
-DataInterpolations directly. DataDrivenDiffEq's own kernel-based collocation
+DataInterpolations directly. `Curvefit` uses CurveFit.jl's nonlinear least-squares
+algorithms, which DataDrivenDiffEq loads when it provides this reexport. DataDrivenDiffEq's
+own kernel-based collocation
 (`EpanechnikovKernel`, `GaussianKernel`, `collocate_data`, …) is documented under
 [Utilities](utils.md).
 

--- a/src/DataDrivenDiffEq.jl
+++ b/src/DataDrivenDiffEq.jl
@@ -34,6 +34,7 @@ using StatsBase: StatsBase, UnitRangeTransform, ZScoreTransform, summarystats
 using StatsAPI: StatsAPI, StatisticalModel, aic, aicc, bic, dof, fit, loglikelihood,
     nobs, nullloglikelihood, r2, rss
 
+import CurveFit
 import DataInterpolations
 using DataInterpolations: BSplineApprox, BSplineInterpolation, ConstantInterpolation,
     CubicSpline, Curvefit, LagrangeInterpolation, LinearInterpolation,

--- a/test/Core/utils.jl
+++ b/test/Core/utils.jl
@@ -3,6 +3,20 @@ using DataDrivenDiffEq: collocate_data
 using DataInterpolations: CubicSpline, LinearInterpolation, QuadraticInterpolation
 using LinearAlgebra
 
+@testset "DataInterpolations reexports" begin
+    t = collect(0.0:1.0:5.0)
+    model(t, p) = @. p[1] + p[2] * t
+    u = model(t, [1.0, 2.0])
+
+    curvefit = Curvefit(u, t, model, [0.5, 1.5])
+    @test curvefit.(t) ≈ u
+
+    interpolation = BSplineInterpolation(u, t, 3, :Average)
+    approximation = BSplineApprox(u, t, 3, 4, :Average)
+    @test interpolation.(t) ≈ u
+    @test all(isfinite, approximation.(t))
+end
+
 @testset "Optimal Shrinkage" begin
     t = collect(-2:0.01:2)
     U = [cos.(t) .* exp.(-t .^ 2) sin.(2 * t)]


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

DataInterpolations 9.2 moved `Curvefit` from an Optim.jl extension to a CurveFit.jl extension, and v10 made that breaking API line explicit. DataDrivenDiffEq continued to export `Curvefit` without loading its implementation, so `using DataDrivenDiffEq; Curvefit(...)` raised a `MethodError`.

This PR loads CurveFit as an MIT-compatible direct dependency, raises the DataInterpolations floor to the first CurveFit-based release, allows DataInterpolations 10, and tests both the CurveFit constructor and the reparameterized v10 B-spline constructors. CurveFit's MIT Expat license is compatible with DataDrivenDiffEq's MIT license: https://github.com/SciML/CurveFit.jl/blob/master/LICENSE.md

DataInterpolations v10 release notes: https://github.com/SciML/DataInterpolations.jl/releases/tag/v10.0.0

## Verification

### Failing before the fix

With the regression test added but before loading CurveFit or changing compat:

```console
$ TMPDIR=/home/crackauc/tmp GROUP=Core julia +release --project=. -e 'using Pkg; Pkg.test()'
DataInterpolations reexports: Error During Test
  MethodError: no method matching Curvefit(::Vector{Float64}, ::Vector{Float64}, ...)
Test Summary:                  | Pass  Error  Total
Utilities                      |   32      1     33
  DataInterpolations reexports |           1      1
ERROR: Some tests did not pass: 32 passed, 0 failed, 1 errored, 0 broken.
```

### Passing after the fix

```console
$ TMPDIR=/home/crackauc/tmp GROUP=Core julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total
Utilities     |   35     35
Test Summary: | Pass  Total
Developer API |   33     33
Testing DataDrivenDiffEq tests passed
```

The Core group passed 282/282 assertions in total.

```console
$ TMPDIR=/home/crackauc/tmp GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total
Quality Assurance |   96     96
Test Summary:       | Pass  Total
JET Static Analysis |   11     11
Testing DataDrivenDiffEq tests passed
```

```console
$ julia +release --project=@v1.12 -m Runic --check src/DataDrivenDiffEq.jl test/Core/utils.jl
$ typos Project.toml src/DataDrivenDiffEq.jl test/Core/utils.jl docs/src/reexports.md
```

Both commands exited successfully with no output.

The declared lower bounds were tested in an isolated environment:

```console
Status `~/tmp/jl_g6rvPV/Project.toml`
  [5a033b19] CurveFit v1.8.1
  [82cc6244] DataInterpolations v9.2.0
minimum compatibility constructors passed
```

The docs build passed with Documenter 1.17.0, the version used by the latest successful master docs run:

```console
$ TMPDIR=/home/crackauc/tmp julia +release --project=docs docs/make.jl
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="1.16.0"` for inventory from ../Project.toml
```

## Not verified / reviewer attention

- Sublibrary-specific groups and Julia prerelease jobs were not run locally; this change is limited to the root package's dependency and reexport surface.
- Documenter 1.18.0 currently fails identically on clean master because it no longer resolves an existing `DMDSVD` reference. The version boundary and reproduction are tracked separately at https://github.com/SciML/DataDrivenDiffEq.jl/issues/673.
- The compat floor deliberately moves from DataInterpolations 9.0 to 9.2 because 9.0–9.1 use the removed Optim-based `Curvefit` contract. CurveFit 1.8.1 is the first CurveFit release that resolves with DataDrivenDiffEq's SciMLBase 3 requirement.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5; session: local Codex session ID 01a0588b-a3c5-7040-8363-097859b8f435).
