### PR TITLE
Fix FBDMD documentation cross-reference

### DIFF
--- a/lib/DataDrivenDMD/src/algorithms.jl
+++ b/lib/DataDrivenDMD/src/algorithms.jl
@@ -259,7 +259,7 @@ end
 $(TYPEDEF)
 
 Approximates the Koopman operator `K` via the forward-backward DMD.
-It is assumed that `K = sqrt(K₁*inv(K₂))`, where `K₁` is the approximation via forward and `K₂` via [DMDSVD](@ref). Based on [this paper](https://arxiv.org/pdf/1507.02264).
+It is assumed that `K = sqrt(K₁*inv(K₂))`, where `K₁` is the approximation via forward and `K₂` via [`DMDSVD`](@ref). Based on [this paper](https://arxiv.org/pdf/1507.02264).
 
 If `truncation` ∈ (0, 1) is given, the singular value decomposition is reduced to include only
 entries bigger than `truncation*maximum(Σ)`. If `truncation` is an integer, the reduced SVD up to `truncation` is used for computation.


### PR DESCRIPTION
## Summary

Documenter 1.18 tightened `@ref` syntax so plain link text targets headings and code-form link text targets docstrings. Mark `DMDSVD` as code in the `FBDMD` docstring so strict cross-reference validation resolves the documented type again, without changing Documenter settings.

> Ignore this PR until reviewed by @ChrisRackauckas.

## Root cause

The failing workflow upgraded from Documenter 1.17.0 to 1.18.0. A minimized strict-docs `git bisect` identified JuliaDocs/Documenter.jl commit [`16a8cdcb32c6dd79bb2b045c41108d6e3ad39943`](https://github.com/JuliaDocs/Documenter.jl/commit/16a8cdcb32c6dd79bb2b045c41108d6e3ad39943), which intentionally made `[Name](@ref)` a heading reference and ``[`Name`](@ref)`` a docstring reference. The stale `FBDMD` docstring used the former syntax for the `DMDSVD` type.

No separate runtime test was added: the strict documentation build is the exact discriminating regression test, and runtime behavior is unchanged.

## Failing before

On unmodified `master` at `d3325ea95ac70812e6a004e8e63020e0f31e7aff`:

```console
$ julia +release --project=docs docs/make.jl
[ Info: CrossReferences: building cross-references.
┌ Error: Cannot resolve @ref for md"[DMDSVD](@ref)" in docs/src/libs/datadrivendmd/koopman.md.
│ - Header or `@id` anchor with slug 'DMDSVD' in docs/src/libs/datadrivendmd/koopman.md does not exist.
│ - Header or `@id` anchor with slug 'DMDSVD' is not unique in docs/src/libs/datadrivendmd/koopman.md.
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

This reproduces the failure in https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33438015785/job/99639084750.

## Passing after

The same command with this one-line source fix, using Julia 1.12.6 and Documenter 1.19.0:

```console
$ julia +release --project=docs docs/make.jl
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="1.16.0"` for inventory from ../Project.toml
┌ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
```

The process exited successfully; local deployment was skipped as expected.

## Verification

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Quality Assurance |   96     96  2m01.1s
Test Summary:       | Pass  Total   Time
JET Static Analysis |   11     11  40.0s
Testing DataDrivenDiffEq tests passed

$ GROUP=DataDrivenDMD_QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary:       | Pass  Total  Time
Developer interface |    9      9  4.5s
Test Summary: | Pass  Total     Time
QA            |   21     21  2m36.1s
Testing DataDrivenDMD tests passed
Testing DataDrivenDiffEq tests passed

$ julia +release --project=.tmp/runic-env -m Runic --check lib/DataDrivenDMD/src/algorithms.jl
# exit 0

$ typos lib/DataDrivenDMD/src/algorithms.jl
# exit 0
```

GPU and downstream jobs were not run because this is a documentation-link syntax correction with no runtime code change.

## Links

- Failing CI job: https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/33438015785/job/99639084750
- Documenter behavior change: https://github.com/JuliaDocs/Documenter.jl/pull/2678

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
