### PR TITLE
Release DataDrivenDMD 0.1.8

### DIFF
--- a/lib/DataDrivenDMD/Project.toml
+++ b/lib/DataDrivenDMD/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDMD"
 uuid = "3c9adf31-5280-42ff-b439-b71cc6b07807"
 authors = ["JuliusMartensen <julius.martensen@gmail.com>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `DataDrivenDMD` 0.1.7 -> 0.1.8 (patch).

Source files changed since 0.1.7:
- `src/algorithms.jl`

Commits:
- Source changes in src/algorithms.jl

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
