### PR TITLE
Release DataDrivenDiffEq 1.16.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataDrivenDiffEq"
 uuid = "2445eb08-9709-466a-b3fc-47e12bd697a2"
 authors = ["Julius Martensen <julius.martensen@gmail.com>"]
-version = "1.16.0"
+version = "1.16.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `DataDrivenDiffEq` 1.16.0 -> 1.16.1 (patch).

Source files changed since 1.16.0:
- `src/DataDrivenDiffEq.jl`

Commits:
- Develop all DataDrivenDiffEq lib/* in Downstream CI (#664)
- Raise Symbolics and IntervalArithmetic floors for downgrade sublibraries (#665)
- Release 0.3.0 (#666)
- Release 0.1.9 (#667)
- Fix remaining interval(extrema(...)) in DataDrivenLux tests (#668)
- Format for Runic v1.10 (#669)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
