### PR TITLE
Require Symbolics 7.39.1 (32-bit hash fix)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -58,7 +58,7 @@ Statistics = "1"
 StatsBase = "0.34"
 StatsAPI = "1.1"
 SymbolicUtils = "4"
-Symbolics = "7.39.1"
+Symbolics = "7.39.2"
 Test = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -58,7 +58,7 @@ Statistics = "1"
 StatsBase = "0.34"
 StatsAPI = "1.1"
 SymbolicUtils = "4"
-Symbolics = "7.37"
+Symbolics = "7.39.1"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
- Bump `[compat] Symbolics` lower bound to **7.39.1** (General#167565).
- Clears the 32-bit `hash(::BasicSymbolic, ::UInt64)` / `trunc(UInt32, …)` failures on x86 CI.

## Test plan
- [ ] x86 Core lane green with Symbolics 7.39.1
- [ ] x64 unaffected

Made with [Cursor](https://cursor.com)