### PR TITLE
Allowlist public implicits identifier for typos 1.50

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,9 @@
 # Pre-existing typos in public API (breaking to fix)
 expresssion = "expresssion"
 
+# Public Basis keyword matching implicit_variables
+implicits = "implicits"
+
 # Julia-specific functions
 indexin = "indexin"
 findfirst = "findfirst"


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`crate-ci/typos` 1.50.0 added `implicits -> implicit` to the dictionary ([crate-ci/typos#1611](https://github.com/crate-ci/typos/pull/1611), [v1.50.0](https://github.com/crate-ci/typos/releases/tag/v1.50.0)). DataDrivenDiffEq uses `implicits` as a public `Basis` keyword and as a local name matching `implicit_variables`; renaming would be noisy and breaking. SciML/.github's reusable Spell Check workflow `@v1` now pins `crate-ci/typos@v1.50.1` ([SciML/.github#129](https://github.com/SciML/.github/pull/129)), so Spell Check fails on current master and on unrelated PRs such as [#681](https://github.com/SciML/DataDrivenDiffEq.jl/pull/681).

This PR only adds `implicits = "implicits"` to `.typos.toml` `[default.extend-words]`.

## Bisect

The identifier is not a recent DataDrivenDiffEq regression.

- **First commit with unallowlisted `implicits`:** [`a0145ce982a3abec100ef32f42629676a7334939`](https://github.com/SciML/DataDrivenDiffEq.jl/commit/a0145ce982a3abec100ef32f42629676a7334939) (`Get ready for implicit optimizers`, 2021-03-29). Found by `git bisect` over current master: bad iff a `.jl` file contains `implicits` and `.typos.toml` does not allowlist it.
- **The `candidate.jl` occurrence** (`implicits = implicit_variables(basis)`) landed in [`dc6c7b3d4c9291090f9be07f4a92e9cd374a7a41`](https://github.com/SciML/DataDrivenDiffEq.jl/commit/dc6c7b3d4c9291090f9be07f4a92e9cd374a7a41) (`Lux (#427)`, 2022-12-18).
- **Spell Check was added later** ([`8526cd292905ae49a81eba4b50773f8b06f42c8a`](https://github.com/SciML/DataDrivenDiffEq.jl/commit/8526cd292905ae49a81eba4b50773f8b06f42c8a), 2025-07-29) with `crate-ci/typos@v1.18.0`, which did not flag `implicits`.
- **CI started failing when typos became stricter:** dictionary change in [typos v1.50.0](https://github.com/crate-ci/typos/releases/tag/v1.50.0) (2026-08-28); reusable workflow bump [SciML/.github#129](https://github.com/SciML/.github/pull/129) merged 2026-09-07 (`crate-ci/typos` 1.49.0 → 1.50.1). DataDrivenDiffEq calls `SciML/.github/.github/workflows/spellcheck.yml@v1`. Confirmed locally: typos 1.47.0 / 1.48.0 / 1.49.0 exit 0 on master; 1.50.0 and 1.50.1 exit 2 with 57 `implicits` hits.

[#680](https://github.com/SciML/DataDrivenDiffEq.jl/pull/680) already mixed this same allowlist line into the x86-lane drop. Once this lands, that line can be dropped from #680 so that PR stays single-purpose.

## Verification

Master `9d31f922` with `typos-cli 1.50.1` (CI pin):

```
$ typos   # crate-ci/typos v1.50.1
error: `implicits` should be `implicit`
    ╭▸ ./lib/DataDrivenLux/src/caches/candidate.jl:268:9
    │
268 │         implicits = implicit_variables(basis),
    ╰╴        ━━━━━━━━━
# 57 errors, all `implicits`; exit 2
```

This branch with the same binary:

```
$ typos   # crate-ci/typos v1.50.1
# no output; exit 0
```

Local default `typos-cli 1.47.0` still passes (it never flagged `implicits`).

## What I did not verify

- Julia test groups, QA, docs build, GPU, downstream: not applicable; this PR only edits `.typos.toml`.
- I did not change `crate-ci/typos` or SciML/.github; those stay on the floating `@v1` reusable workflow.

## Reviewer notes

- `implicits` is public API (`Basis(..., implicits = ...)`), not a misspelling of `implicit`. Allowlisting is the intended SciML fix; a rename would be breaking.
- Mechanical one-file change; no behavior change.

🤖 Generated with Grok Build 1.0.24 (model: grok-4.6)
Agent-Session: 01a08654-45f1-7a53-849c-56a7f1531d56 (local Grok Build session; no public conversation URL)

## Links

- Failing PR Spell Check: https://github.com/SciML/DataDrivenDiffEq.jl/pull/681
- Failed Spell Check run: https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/34358807499
- Identifier origin: https://github.com/SciML/DataDrivenDiffEq.jl/commit/a0145ce982a3abec100ef32f42629676a7334939
- candidate.jl occurrence: https://github.com/SciML/DataDrivenDiffEq.jl/commit/dc6c7b3d4c9291090f9be07f4a92e9cd374a7a41
- Spell Check added: https://github.com/SciML/DataDrivenDiffEq.jl/commit/8526cd292905ae49a81eba4b50773f8b06f42c8a
- typos dictionary PR: https://github.com/crate-ci/typos/pull/1611
- typos v1.50.0: https://github.com/crate-ci/typos/releases/tag/v1.50.0
- SciML/.github typos bump: https://github.com/SciML/.github/pull/129
- SciML/.github bump commit: https://github.com/SciML/.github/commit/d2448a9f7888ee6d5f4befe8229ff350ad0e24e4
- Mixed allowlist on #680: https://github.com/SciML/DataDrivenDiffEq.jl/pull/680