### PR TITLE
Allow JET 0.12 in the QA test environment

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,7 +8,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-JET = "0.9, 0.10, 0.11"
+JET = "0.9, 0.10, 0.11, 0.12"
 SafeTestsets = "0.0.1, 0.1"
 SciMLTesting = "2.4"
 Test = "1"


### PR DESCRIPTION
## Summary

The QA job on the `julia '1'` lane (Julia 1.13.0) resolves JET 0.11.6, which reports false-positive runtime dispatches for fully-concrete `Base` broadcast/materialize/iterate code on 1.13 (JET.jl#839, fixed in JET 0.12). `test/qa/jet_tests.jl` fails four `@test_opt` checks — `polynomial_basis`, `chebyshev_basis`, `fourier_basis`, and `_construct_datadrivenproblem`.

- Failing run: https://github.com/SciML/DataDrivenDiffEq.jl/actions/runs/34655428411

This broadens the QA JET compat to include 0.12, matching the fix in SimpleDiffEq.jl#144. JET ≥ 0.11.4 requires Julia 1.12, so the LTS lane keeps resolving an older JET and is unaffected.

## Test plan

- [x] `test/qa/jet_tests.jl` on Julia 1.13.0: 4 failures under JET 0.11.6 (as in CI), all 11 pass under JET 0.12.1
- [x] `test/qa/qa.jl` passes on Julia 1.13.0 (20/20 + 76/76 reexport checks)
- [ ] CI

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max). Session: local session, `/home/crackauc/.local/share/devin/cli/sessions.db`